### PR TITLE
Initialize project documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,4 @@ This repository welcomes improvements from automated agents and human contributo
 * There are currently no automated tests. Mention this in your PR summary and consider adding tests using `pytest`.
 * Summaries and PR messages should include citations to relevant files.
 * Append new questions to `docs/FAQ.md` rather than removing existing items.
+* Run `pytest` to confirm tests pass (even if none are collected) before opening a PR.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Instructions for LLM Contributors
+
+This repository welcomes improvements from automated agents and human contributors. Please follow these guidelines:
+
+* Keep user privacy and security central. Avoid adding analytics or unapproved network calls.
+* Use lightweight, well-understood dependencies. Discuss heavy additions before including them.
+* Update documentation (`README.md`, files under `docs/`) whenever behavior or design changes.
+* If you introduce code, prefer Python 3.10+ and standard tooling. Provide a `requirements.txt` if dependencies are needed.
+* There are currently no automated tests. Mention this in your PR summary and consider adding tests using `pytest`.
+* Summaries and PR messages should include citations to relevant files.
+* Append new questions to `docs/FAQ.md` rather than removing existing items.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Gabriel
 
-Gabriel is an open source "guardian angel" LLM aimed at helping individuals securely navigate the digital world. The project intends to provide actionable security advice, maintain personal knowledge about the user's environment (with their consent), and eventually offer local AI-assisted monitoring. Our guiding principle is to keep user data private and handle AI inference locally via [token.place](https://github.com/futuroptimist/token.place).
+Gabriel is an open source "guardian angel" LLM aimed at helping individuals securely navigate the digital world. The project intends to provide actionable security advice, maintain personal knowledge about the user's environment (with their consent), and eventually offer local AI-assisted monitoring. Our guiding principle is to keep user data private and handle AI inference locally. When possible we rely on [token.place](https://github.com/futuroptimist/token.place) for encrypted inference, though a fully offline path using components like `llama-cpp-python` is also supported.
 
 ## Goals
 
 - Offer community-first, dignity-focused security guidance.
-- Integrate with token.place to run LLMs locally, avoiding cloud exfiltration.
-- Encourage cross-project collaboration with [dspace](https://github.com/democratizedspace/dspace), [f2clipboard](https://github.com/futuroptimist/f2clipboard), and similar efforts.
+- Integrate with token.place or fully local inference to avoid cloud exfiltration.
+- Encourage collaboration with [token.place](https://github.com/futuroptimist/token.place) and [sigma](https://github.com/futuroptimist/sigma) as complementary projects.
 - Provide a gentle on-ramp toward eventual real-world monitoring capabilities.
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-# gabriel
-guardian angel LLM to help you navigate the dark forest.
+# Gabriel
+
+Gabriel is an open source "guardian angel" LLM aimed at helping individuals securely navigate the digital world. The project intends to provide actionable security advice, maintain personal knowledge about the user's environment (with their consent), and eventually offer local AI-assisted monitoring. Our guiding principle is to keep user data private and handle AI inference locally via [token.place](https://github.com/futuroptimist/token.place).
+
+## Goals
+
+- Offer community-first, dignity-focused security guidance.
+- Integrate with token.place to run LLMs locally, avoiding cloud exfiltration.
+- Encourage cross-project collaboration with [dspace](https://github.com/democratizedspace/dspace), [f2clipboard](https://github.com/futuroptimist/f2clipboard), and similar efforts.
+- Provide a gentle on-ramp toward eventual real-world monitoring capabilities.
+
+## Roadmap
+
+See [docs/ROADMAP.md](docs/ROADMAP.md) for a more detailed roadmap. Early milestones include:
+
+1. Establishing repository guidelines and a base documentation structure.
+2. Collecting security best practices for self-hosted services.
+3. Prototyping local LLM inference through token.place.
+
+## Contributing
+
+We use `AGENTS.md` to outline repository-specific instructions for automated agents. Please read it before opening pull requests.
+
+## FAQ
+
+We maintain an evolving list of questions for clarification in [docs/FAQ.md](docs/FAQ.md). Feel free to add your own or answer existing ones.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,16 @@
+# FAQ
+
+This FAQ lists questions we have for the maintainers and community. Answers will be filled in as the project evolves.
+
+1. **Preferred programming languages and frameworks?**
+2. **Expected integration points with [token.place](https://github.com/futuroptimist/token.place)?**
+3. **Guidelines for storing user data securely?**
+4. **Policies on network access or telemetry?**
+5. **How should we coordinate with other projects like dspace and f2clipboard?**
+6. **Are there existing datasets or knowledge bases we can leverage?**
+7. **What level of automated testing is required for contributions?**
+8. **Any contributor license agreements or code of conduct?**
+9. **Are external contributions currently welcome, or is this in a closed alpha?**
+10. **Desired repository structure or directories to avoid?**
+
+Feel free to extend this list with additional questions or provide answers in follow-up pull requests.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -3,14 +3,24 @@
 This FAQ lists questions we have for the maintainers and community. Answers will be filled in as the project evolves.
 
 1. **Preferred programming languages and frameworks?**
+   - No strict preference, but Python is recommended initially due to its strong machine learning ecosystem.
 2. **Expected integration points with [token.place](https://github.com/futuroptimist/token.place)?**
+   - Gabriel can run models locally on CPU/GPU or call token.place's encrypted inference API when desired.
 3. **Guidelines for storing user data securely?**
+   - Use robust `.gitignore` rules and pre-commit hooks. Encourage filesystem encryption and careful handling of secrets.
 4. **Policies on network access or telemetry?**
+   - Local only by default and encrypted at rest; no telemetry is sent upstream.
 5. **How should we coordinate with other projects like dspace and f2clipboard?**
+   - Focus on integrating token.place first. Additional collaborations may come later.
 6. **Are there existing datasets or knowledge bases we can leverage?**
+   - None specified yet, but community suggestions are welcome.
 7. **What level of automated testing is required for contributions?**
+   - Use GitHub Actions and pre-commit hooks. Tests with `pytest` are encouraged.
 8. **Any contributor license agreements or code of conduct?**
+   - The project is MIT licensed and a contributors guide will outline code of conduct.
 9. **Are external contributions currently welcome, or is this in a closed alpha?**
+   - Contributions are welcome via pull request.
 10. **Desired repository structure or directories to avoid?**
+   - Keep the layout intuitive; there are no forbidden directories at this time.
 
 Feel free to extend this list with additional questions or provide answers in follow-up pull requests.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -18,7 +18,7 @@ This document outlines tentative phases for Gabriel. Dates are aspirational and 
 
 - Organize user notes and security data into a searchable store.
 - Provide advanced LLM-driven recommendations.
-- Explore synergy with other projects like dspace robotics and f2clipboard workflows.
+- Explore synergy with [sigma](https://github.com/futuroptimist/sigma) as a push-to-talk interface for local LLM interactions.
 
 ## Phase 3+: Real World Monitoring (long term)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,26 @@
+# Roadmap
+
+This document outlines tentative phases for Gabriel. Dates are aspirational and subject to change.
+
+## Phase 0: Foundation
+
+- Add project documentation (README, FAQ, AGENTS).
+- Outline security best practice checklists.
+- Provide minimal CLI or script scaffolding for experiments.
+
+## Phase 1: Local Security Advisor
+
+- Collect user-consented configuration data.
+- Suggest improvements for self-hosted services such as PhotoPrism and VaultWarden.
+- Integrate token.place for local LLM inference.
+
+## Phase 2: Personal Knowledge Manager
+
+- Organize user notes and security data into a searchable store.
+- Provide advanced LLM-driven recommendations.
+- Explore synergy with other projects like dspace robotics and f2clipboard workflows.
+
+## Phase 3+: Real World Monitoring (long term)
+
+- Introduce optional home monitoring via sensors or robotics.
+- Emphasize privacy, encryption, and user control at all times.

--- a/prompts/README.md
+++ b/prompts/README.md
@@ -1,0 +1,15 @@
+# Prompt Templates
+
+This directory collects example prompts for using an LLM with Gabriel. These prompts are exploratory and will evolve.
+
+## Example: Summarize Security Posture
+
+```
+You are Gabriel, a privacy-first assistant. Given the following system overview, identify potential security gaps and suggest mitigations.
+
+<system_overview>
+...paste output from inventory scripts here...
+</system_overview>
+```
+
+Contributions of new prompt templates are welcome. Keep them general and avoid leaking personal information.


### PR DESCRIPTION
## Summary
- add project overview and goals to README
- outline roadmap for upcoming phases
- pose open questions in a new FAQ
- create AGENTS instructions for LLM contributors
- add initial prompt template examples

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685f39dc2dc8832fae02d8c3000bff04