### PR TITLE
Add threat model and CI scaffolding

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,2 @@
+[bandit]
+exclude = tests

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+exclude = .git,__pycache__,build,dist

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 bandit
+      - name: Run Flake8
+        run: flake8 .
+      - name: Run Bandit
+        run: bandit -r .

--- a/README.md
+++ b/README.md
@@ -2,12 +2,45 @@
 
 Gabriel is an open source "guardian angel" LLM aimed at helping individuals securely navigate the digital world. The project intends to provide actionable security advice, maintain personal knowledge about the user's environment (with their consent), and eventually offer local AI-assisted monitoring. Our guiding principle is to keep user data private and handle AI inference locally. When possible we rely on [token.place](https://github.com/futuroptimist/token.place) for encrypted inference, though a fully offline path using components like `llama-cpp-python` is also supported.
 
+![License](https://img.shields.io/github/license/futuroptimist/gabriel)
+
 ## Goals
 
 - Offer community-first, dignity-focused security guidance.
 - Integrate with token.place or fully local inference to avoid cloud exfiltration.
 - Encourage collaboration with [token.place](https://github.com/futuroptimist/token.place) and [sigma](https://github.com/futuroptimist/sigma) as complementary projects.
 - Provide a gentle on-ramp toward eventual real-world monitoring capabilities.
+
+## Architecture Overview
+
+The project is organized into four tentative modules:
+
+1. **Ingestion** – scripts or agents that collect user-consented data.
+2. **Analysis** – LLM-based logic for assessing security posture.
+3. **Notification** – optional alerts or recommendations sent to the user.
+4. **User Interface** – CLI or lightweight UI for interacting with Gabriel.
+
+This modular structure keeps responsibilities clear and allows future extensions like phishing detection or network monitoring.
+
+## Getting Started
+
+Gabriel requires Python 3.10 or later. Clone the repository and install dependencies:
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+Run `pytest` (even though no tests exist yet) to ensure your environment is ready:
+
+```bash
+pytest
+```
+
+## Threat Model
+
+See [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md) for security assumptions and mitigations. In short, secrets should be stored outside of version control and logs should avoid PII.
 
 ## Roadmap
 
@@ -19,7 +52,11 @@ See [docs/ROADMAP.md](docs/ROADMAP.md) for a more detailed roadmap. Early milest
 
 ## Contributing
 
-We use `AGENTS.md` to outline repository-specific instructions for automated agents. Please read it before opening pull requests.
+We use `AGENTS.md` to outline repository-specific instructions for automated agents. Additional contributor guidelines live in [docs/CONTRIBUTING.md](docs/CONTRIBUTING.md). Please read them before opening pull requests.
+
+## CI & Security
+
+The repository includes a GitHub Actions workflow that runs `flake8` and `bandit` to catch style issues and common security mistakes. Dependabot is configured to monitor Python dependencies weekly.
 
 ## FAQ
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+We welcome pull requests that improve Gabriel's security posture, documentation, or functionality. Before contributing, please:
+
+1. Read [`AGENTS.md`](../AGENTS.md) for repository-specific automation rules.
+2. Ensure any code changes support Python 3.10+ and include minimal tests with `pytest` when applicable.
+3. Document new behavior in `README.md` or under `docs/`.
+4. Run `flake8` and `bandit` locally to catch style and security issues.
+
+By contributing you agree to license your work under the repository's MIT license.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -22,5 +22,7 @@ This FAQ lists questions we have for the maintainers and community. Answers will
    - Contributions are welcome via pull request.
 10. **Desired repository structure or directories to avoid?**
    - Keep the layout intuitive; there are no forbidden directories at this time.
+11. **Is there a defined threat model for Gabriel?**
+   - See [docs/THREAT_MODEL.md](THREAT_MODEL.md) for the latest threat model and security assumptions.
 
 Feel free to extend this list with additional questions or provide answers in follow-up pull requests.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -1,0 +1,23 @@
+# Threat Model
+
+Gabriel aims to act as a privacy-first assistant that helps users maintain situational awareness about their digital security. The initial focus is on local execution with optional encrypted inference through [token.place](https://github.com/futuroptimist/token.place).
+
+## Security Assumptions
+
+- Users operate Gabriel on hardware they control.
+- Network connectivity is optional and should be minimized.
+- Secrets such as API keys should be stored in environment variables or encrypted files, never committed to source control.
+- Logs must avoid collecting personally identifiable information (PII) by default.
+
+## Attack Surface
+
+- Compromise of the local machine running Gabriel.
+- Leakage of secrets through misconfigured logging or unencrypted storage.
+- Exposure when calling external APIs if not using an encrypted channel.
+
+## Mitigations
+
+- Encourage filesystem encryption and strong access controls.
+- Provide examples of secure key storage using tools like `keyring` or OS keychains.
+- Limit logs to debug-level messages and strip sensitive data before writing.
+- Prefer offline models or encrypted inference when possible.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# Core dependencies will be added as the project evolves


### PR DESCRIPTION
## Summary
- document threat model and contributing standards
- update FAQ with a threat model question
- expand README with architecture overview, setup and security notes
- add flake8/bandit CI workflow and weekly Dependabot updates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686245fe946c832f8571c153279169af