### PR TITLE
Add initial tests and security utilities

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,2 @@
 [bandit]
-exclude = tests
+exclude = tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*.so
+
+# Virtual environment
+.venv/
+
+# Coverage
+.coverage
+htmlcov/
+
+# Test results
+.tox/
+
+# Editor files
+*.swp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This repository welcomes improvements from automated agents and human contributo
 * Use lightweight, well-understood dependencies. Discuss heavy additions before including them.
 * Update documentation (`README.md`, files under `docs/`) whenever behavior or design changes.
 * If you introduce code, prefer Python 3.10+ and standard tooling. Provide a `requirements.txt` if dependencies are needed.
-* There are currently no automated tests. Mention this in your PR summary and consider adding tests using `pytest`.
+* Basic tests live under `tests/`. Run `pytest` and consider adding coverage for new code.
 * Summaries and PR messages should include citations to relevant files.
 * Append new questions to `docs/FAQ.md` rather than removing existing items.
 * Run `pytest` to confirm tests pass (even if none are collected) before opening a PR.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The project is organized into four tentative modules:
 3. **Notification** – optional alerts or recommendations sent to the user.
 4. **User Interface** – CLI or lightweight UI for interacting with Gabriel.
 
-This modular structure keeps responsibilities clear and allows future extensions like phishing detection or network monitoring.
+This modular structure keeps responsibilities clear and allows future extensions like phishing detection or network monitoring. A small `gabriel.security` module demonstrates helper functions such as password strength checks and log sanitization, complete with tests.
 
 ## Getting Started
 
@@ -32,10 +32,16 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Run `pytest` (even though no tests exist yet) to ensure your environment is ready:
+Run `pytest` to exercise the test suite:
 
 ```bash
 pytest
+```
+Optionally check coverage:
+
+```bash
+coverage run -m pytest
+coverage report
 ```
 
 ## Threat Model

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -28,3 +28,5 @@ This FAQ lists questions we have for the maintainers and community. Answers will
    - Risks and mitigations for continuous automation are described in [docs/FLYWHEEL_RISK_MODEL.md](FLYWHEEL_RISK_MODEL.md).
 
 Feel free to extend this list with additional questions or provide answers in follow-up pull requests.
+13. **Is test coverage tracked?**
+   - Basic tests live under `tests/`. Use `coverage run -m pytest` followed by `coverage report` to see coverage statistics.

--- a/gabriel/__init__.py
+++ b/gabriel/__init__.py
@@ -1,0 +1,5 @@
+"""Utility functions for Gabriel."""
+
+from .security import is_strong_password, sanitize_log_line
+
+__all__ = ["is_strong_password", "sanitize_log_line"]

--- a/gabriel/security.py
+++ b/gabriel/security.py
@@ -1,0 +1,21 @@
+"""Basic security helpers for Gabriel."""
+
+import re
+from typing import Pattern
+
+_EMAIL_PATTERN: Pattern[str] = re.compile(r"[\w\.-]+@[\w\.-]+")
+
+
+def is_strong_password(password: str) -> bool:
+    """Return True if the password appears strong."""
+    if len(password) < 8:
+        return False
+    has_lower = any(c.islower() for c in password)
+    has_upper = any(c.isupper() for c in password)
+    has_digit = any(c.isdigit() for c in password)
+    return has_lower and has_upper and has_digit
+
+
+def sanitize_log_line(line: str) -> str:
+    """Redact email addresses from log lines."""
+    return _EMAIL_PATTERN.sub("<redacted>", line)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-# Core dependencies will be added as the project evolves
+pytest
+coverage

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -1,0 +1,19 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from gabriel.security import is_strong_password, sanitize_log_line
+
+
+def test_is_strong_password():
+    assert is_strong_password("Abcdef1g")  # nosec B101
+    assert not is_strong_password("short")  # nosec B101
+    assert not is_strong_password("alllowercase1")  # nosec B101
+    assert not is_strong_password("ALLUPPERCASE1")  # nosec B101
+    assert not is_strong_password("NoDigits")  # nosec B101
+
+
+def test_sanitize_log_line():
+    line = "User email is user@example.com in log"
+    assert sanitize_log_line(line) == "User email is <redacted> in log"  # nosec B101


### PR DESCRIPTION
## Summary
- add basic `gabriel.security` helpers with password strength check and log redaction
- create tests exercising the new module
- update README with testing and coverage instructions
- update AGENTS instructions and FAQ
- add `.gitignore`

## Testing
- `flake8 .`
- `bandit -r .`
- `pytest -q`
- `coverage run -m pytest -q && coverage report`

------
https://chatgpt.com/codex/tasks/task_e_6868c8663bc0832f9ba5298c961cb612