### PR TITLE
Add coverage reporting and badge

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,29 @@
+name: Coverage
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=gabriel --cov-report=term-missing --cov-report=xml
+          coverage-badge -o coverage.svg -f
+      - name: Commit coverage badge
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: coverage.svg
+          message: "chore: update coverage badge [skip ci]"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+
+# Coverage reports
+.coverage
+coverage.xml
+
+# pytest cache
+.pytest_cache/
+
+# Virtual environments
+.venv/
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ This repository welcomes improvements from automated agents and human contributo
 * Use lightweight, well-understood dependencies. Discuss heavy additions before including them.
 * Update documentation (`README.md`, files under `docs/`) whenever behavior or design changes.
 * If you introduce code, prefer Python 3.10+ and standard tooling. Provide a `requirements.txt` if dependencies are needed.
-* There are currently no automated tests. Mention this in your PR summary and consider adding tests using `pytest`.
+* A minimal test suite exists. Ensure it passes by running `pytest` with coverage before opening a PR.
 * Summaries and PR messages should include citations to relevant files.
 * Append new questions to `docs/FAQ.md` rather than removing existing items.
 * Run `pytest` to confirm tests pass (even if none are collected) before opening a PR.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Gabriel is an open source "guardian angel" LLM aimed at helping individuals securely navigate the digital world. The project intends to provide actionable security advice, maintain personal knowledge about the user's environment (with their consent), and eventually offer local AI-assisted monitoring. Our guiding principle is to keep user data private and handle AI inference locally. When possible we rely on [token.place](https://github.com/futuroptimist/token.place) for encrypted inference, though a fully offline path using components like `llama-cpp-python` is also supported.
 
 ![License](https://img.shields.io/github/license/futuroptimist/gabriel)
+![Coverage](./coverage.svg)
 
 ## Goals
 
@@ -32,10 +33,10 @@ source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
-Run `pytest` (even though no tests exist yet) to ensure your environment is ready:
+Run `pytest` with coverage enabled:
 
 ```bash
-pytest
+python -m pytest --cov=gabriel --cov-report=term-missing
 ```
 
 ## Threat Model

--- a/coverage.svg
+++ b/coverage.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="99" height="20">
+    <linearGradient id="b" x2="0" y2="100%">
+        <stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
+        <stop offset="1" stop-opacity=".1"/>
+    </linearGradient>
+    <mask id="a">
+        <rect width="99" height="20" rx="3" fill="#fff"/>
+    </mask>
+    <g mask="url(#a)">
+        <path fill="#555" d="M0 0h63v20H0z"/>
+        <path fill="#4c1" d="M63 0h36v20H63z"/>
+        <path fill="url(#b)" d="M0 0h99v20H0z"/>
+    </g>
+    <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11">
+        <text x="31.5" y="15" fill="#010101" fill-opacity=".3">coverage</text>
+        <text x="31.5" y="14">coverage</text>
+        <text x="80" y="15" fill="#010101" fill-opacity=".3">100%</text>
+        <text x="80" y="14">100%</text>
+    </g>
+</svg>

--- a/gabriel/__init__.py
+++ b/gabriel/__init__.py
@@ -1,0 +1,5 @@
+"""Core utilities for the Gabriel project."""
+
+from .utils import add
+
+__all__ = ["add"]

--- a/gabriel/utils.py
+++ b/gabriel/utils.py
@@ -1,0 +1,3 @@
+def add(a: int, b: int) -> int:
+    """Return the sum of ``a`` and ``b``."""
+    return a + b

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 # Core dependencies will be added as the project evolves
+pytest
+coverage
+coverage-badge
+pytest-cov

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,5 @@
+from gabriel.utils import add
+
+
+def test_add():
+    assert add(1, 2) == 3  # nosec B101


### PR DESCRIPTION
## Summary
- introduce a minimal `gabriel` package with `utils.add`
- add tests and coverage workflow that publishes `coverage.svg`
- include coverage badge in the README and instructions
- update guidelines in `AGENTS.md`
- ignore coverage artifacts

## Testing
- `python -m pytest -q`
- `flake8 .`
- `bandit -r .`


------
https://chatgpt.com/codex/tasks/task_e_6868e597b9c0832f819d3dbe22f28272