### PR TITLE
Add sugarkube docs to tracked repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ relevant documentation.
 | sigma | [IMPROVEMENTS.md](docs/related/sigma/IMPROVEMENTS.md) | [THREAT_MODEL.md](docs/related/sigma/THREAT_MODEL.md) |
 | gitshelves | [IMPROVEMENTS.md](docs/related/gitshelves/IMPROVEMENTS.md) | [THREAT_MODEL.md](docs/related/gitshelves/THREAT_MODEL.md) |
 | wove | [IMPROVEMENTS.md](docs/related/wove/IMPROVEMENTS.md) | [THREAT_MODEL.md](docs/related/wove/THREAT_MODEL.md) |
+| sugarkube | [IMPROVEMENTS.md](docs/related/sugarkube/IMPROVEMENTS.md) | [THREAT_MODEL.md](docs/related/sugarkube/THREAT_MODEL.md) |
 | PhotoPrism | [IMPROVEMENT_CHECKLISTS.md#photoprism](docs/IMPROVEMENT_CHECKLISTS.md#photoprism) | N/A |
 | VaultWarden | [IMPROVEMENT_CHECKLISTS.md#vaultwarden](docs/IMPROVEMENT_CHECKLISTS.md#vaultwarden) | N/A |
 

--- a/docs/IMPROVEMENT_CHECKLISTS.md
+++ b/docs/IMPROVEMENT_CHECKLISTS.md
@@ -30,6 +30,9 @@ See [related/gitshelves/IMPROVEMENTS.md](related/gitshelves/IMPROVEMENTS.md).
 ## wove
 See [related/wove/IMPROVEMENTS.md](related/wove/IMPROVEMENTS.md).
 
+## sugarkube
+See [related/sugarkube/IMPROVEMENTS.md](related/sugarkube/IMPROVEMENTS.md).
+
 ## PhotoPrism
 - [ ] Enable HTTPS by default and use strong admin credentials.
 - [ ] Store images outside of the application container with strict permissions.

--- a/docs/related/sugarkube/IMPROVEMENTS.md
+++ b/docs/related/sugarkube/IMPROVEMENTS.md
@@ -1,0 +1,9 @@
+# Suggested Improvements for sugarkube
+
+This document lists potential enhancements for the [sugarkube](https://github.com/futuroptimist/sugarkube) repository.
+
+## Checklist
+
+- [ ] Document install steps for offline use.
+- [ ] Provide examples of customizing build workflows.
+- [ ] Outline integration paths with other Futuroptimist projects.

--- a/docs/related/sugarkube/THREAT_MODEL.md
+++ b/docs/related/sugarkube/THREAT_MODEL.md
@@ -1,0 +1,18 @@
+# sugarkube Threat Model
+
+sugarkube automates infrastructure deployments. This outline describes assumed risks and mitigations when using the tool.
+
+## Security Assumptions
+
+- Users run sugarkube on hardware they control.
+- Deployments may target cloud environments with sensitive credentials.
+
+## Potential Risks
+
+- Leaked secrets in deployment configuration files.
+- Misconfigured access controls in generated infrastructure.
+
+## Mitigations
+
+- Keep sensitive values in environment variables or secret stores.
+- Review generated resources for least-privilege permissions.


### PR DESCRIPTION
## Summary
- track sugarkube alongside other related projects
- document sugarkube improvements and threat model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875fce8cab8832f8fd4590784447871