### PR TITLE
Add Codecov upload to workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,6 +22,10 @@ jobs:
         run: |
           pytest --cov=gabriel --cov-report=term-missing --cov-report=xml
           coverage-badge -o coverage.svg -f
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: Commit coverage badge
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: EndBug/add-and-commit@v9

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ We use `AGENTS.md` to outline repository-specific instructions for automated age
 
 ## CI & Security
 
-The repository includes a GitHub Actions workflow that runs `flake8` and `bandit` to catch style issues and common security mistakes. Dependabot is configured to monitor Python dependencies weekly.
+The repository includes GitHub Actions workflows for linting, testing, and documentation. `flake8` and `bandit` catch style issues and common security mistakes, while coverage results are uploaded to [Codecov](https://codecov.io/) after tests run. Dependabot monitors Python dependencies weekly.
 
 ## FAQ
 

--- a/docs/gabriel/FAQ.md
+++ b/docs/gabriel/FAQ.md
@@ -32,5 +32,7 @@ This FAQ lists questions we have for the maintainers and community. Answers will
    - See [../related/token_place/IMPROVEMENTS.md](../related/token_place/IMPROVEMENTS.md) for suggested mitigations against relay compromise and network attacks.
 15. **Why reference the Sword of Damocles in Gabriel's documentation?**
    - The parable illustrates the constant risk that accompanies greater resources and privilege online. [SWORD_OF_DAMOCLES.md](SWORD_OF_DAMOCLES.md) explains how Gabriel aims to alleviate that danger through local, privacy-first design.
+16. **How is test coverage reported?**
+   - Coverage reports are uploaded to [Codecov](https://about.codecov.io/) through a GitHub Actions workflow.
 
 Feel free to extend this list with additional questions or provide answers in follow-up pull requests.


### PR DESCRIPTION
## Summary
- upload coverage data to Codecov
- note Codecov in CI overview
- document coverage reporting in the FAQ

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687b41d0c778832f90e6dbca04e12b1c