### PR TITLE
docs: add prompt templates for repo assessments

### DIFF
--- a/prompts/README.md
+++ b/prompts/README.md
@@ -2,6 +2,12 @@
 
 This directory collects example prompts for using an LLM with Gabriel. These prompts are exploratory and will evolve.
 
+## Prompt Catalog
+
+- [Scan for Bright and Dark Patterns](scan-bright-dark-patterns.md)
+- [Generate Improvement Checklist Items](generate-improvements.md)
+- [Update Flywheel Risk Model](update-risk-model.md)
+
 ## Example: Summarize Security Posture
 
 ```

--- a/prompts/generate-improvements.md
+++ b/prompts/generate-improvements.md
@@ -1,0 +1,12 @@
+# Generate Improvement Checklist Items
+
+"""
+Purpose:
+  Review the codebase to propose updates to docs/gabriel/IMPROVEMENTS.md.
+Context:
+  <insert file tree or code excerpts>
+Request:
+  - Suggest new checklist items with clear action verbs.
+  - Reference relevant files or modules for each suggestion.
+  - Note if an item aligns with flywheel best practices.
+"""

--- a/prompts/scan-bright-dark-patterns.md
+++ b/prompts/scan-bright-dark-patterns.md
@@ -1,0 +1,12 @@
+# Scan for Bright and Dark Patterns
+
+"""
+Purpose:
+  Evaluate documentation and UI code for bright and dark patterns.
+Context:
+  <insert snippets or file paths to review>
+Request:
+  - Identify any dark patterns and explain why they are problematic.
+  - Highlight existing bright patterns.
+  - Suggest improvements to remove dark patterns or strengthen bright ones.
+"""

--- a/prompts/update-risk-model.md
+++ b/prompts/update-risk-model.md
@@ -1,0 +1,12 @@
+# Update Flywheel Risk Model
+
+"""
+Purpose:
+  Assess how a proposed change affects the risk landscape described in docs/gabriel/FLYWHEEL_RISK_MODEL.md.
+Context:
+  <insert description of the change or diff>
+Request:
+  - Determine which sections of the risk model need updates.
+  - Propose wording for new risks or mitigations.
+  - Flag any areas requiring human review.
+"""


### PR DESCRIPTION
## Summary
- add prompts to scan for bright or dark patterns
- add prompt to propose new improvement checklist items
- add prompt to update the flywheel risk model

## Testing
- `pre-commit run --all-files`
- `pytest --cov=gabriel --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_689067b23000832fa6dcd1aea0a990cc