### PR TITLE
📝 : document keyring secret storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Run `pytest` with coverage enabled:
 python -m pytest --cov=gabriel --cov-report=term-missing
 ```
 
+For storing secrets in the system keyring, see
+[docs/gabriel/SECRET_STORAGE.md](docs/gabriel/SECRET_STORAGE.md).
+
 ### Runbook & 3D Viewer
 
 This repo now mirrors flywheel's development helpers. `runbook.yml` lists

--- a/docs/gabriel/IMPROVEMENTS.md
+++ b/docs/gabriel/IMPROVEMENTS.md
@@ -7,6 +7,6 @@ This document lists potential enhancements uncovered during a self-audit of the 
 - [x] Implement `flake8` and `bandit` in CI to catch style and security issues.
 - [x] Expand unit tests beyond the simple `add` function.
 - [x] Add unit tests for negative numbers in arithmetic helpers.
-- [ ] Provide examples of encrypted secret storage using `keyring`.
+- [x] Provide examples of encrypted secret storage using `keyring` ([SECRET_STORAGE.md](SECRET_STORAGE.md)).
 - [ ] Document how to run Gabriel completely offline with local models.
 - [x] Harden pre-commit hooks to prevent accidental secret leaks.

--- a/docs/gabriel/SECRET_STORAGE.md
+++ b/docs/gabriel/SECRET_STORAGE.md
@@ -1,0 +1,27 @@
+# Encrypted Secret Storage
+
+Gabriel can store tokens or other secrets using the
+[keyring](https://pypi.org/project/keyring/) library. It relies on the
+operating system's credential manager.
+
+## Example
+
+```python
+import keyring
+
+SERVICE = "gabriel"
+USERNAME = "sample-user"
+
+def save_token(token: str) -> None:
+    """Save token to the system keyring."""
+    keyring.set_password(SERVICE, USERNAME, token)
+
+def load_token() -> str | None:
+    """Retrieve token from the system keyring."""
+    return keyring.get_password(SERVICE, USERNAME)
+```
+
+Install `keyring` with `pip install keyring` if it is not already
+available. The library encrypts secrets using the platform's preferred
+backend and avoids storing plaintext passwords in the repository or
+environment variables.


### PR DESCRIPTION
what: add doc on storing secrets with keyring and link from README
why: give guidance on secure local secret storage
how: pre-commit run --all-files && pytest --cov=gabriel

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68943656e698832f937f2eeaccc94ee7