### PR TITLE
🔒 fix: handle missing keyring

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -140,4 +140,3 @@ str
 plaintext
 cpp
 GGUF
-

--- a/docs/gabriel/SECRET_STORAGE.md
+++ b/docs/gabriel/SECRET_STORAGE.md
@@ -22,6 +22,7 @@ def load_token() -> str | None:
 ```
 
 Install `keyring` with `pip install keyring` if it is not already
-available. The library encrypts secrets using the platform's preferred
-backend and avoids storing plaintext passwords in the repository or
-environment variables.
+available. Gabriel's ``store_secret`` and ``get_secret`` helpers raise a
+``RuntimeError`` when the package is missing. The library encrypts secrets
+using the platform's preferred backend and avoids storing plaintext
+passwords in the repository or environment variables.

--- a/gabriel/utils.py
+++ b/gabriel/utils.py
@@ -19,8 +19,19 @@ def store_secret(service: str, username: str, secret: str) -> None:
         The user identifier for the secret.
     secret:
         The secret value to store.
+
+    Raises
+    ------
+    RuntimeError
+        If the ``keyring`` package is not installed.
     """
-    import keyring
+    try:
+        import keyring
+    except ImportError as exc:  # pragma: no cover - exercised via tests
+        raise RuntimeError(
+            "The `keyring` package is required to store secrets. "
+            "Install it via `pip install keyring`."
+        ) from exc
 
     keyring.set_password(service, username, secret)
 
@@ -28,8 +39,22 @@ def store_secret(service: str, username: str, secret: str) -> None:
 def get_secret(service: str, username: str) -> str | None:
     """Retrieve a secret from the system keyring.
 
-    Returns ``None`` if no secret is stored for the given ``service`` and ``username``.
+    Returns
+    -------
+    str | None
+        The stored secret or ``None`` if no value is found.
+
+    Raises
+    ------
+    RuntimeError
+        If the ``keyring`` package is not installed.
     """
-    import keyring
+    try:
+        import keyring
+    except ImportError as exc:  # pragma: no cover - exercised via tests
+        raise RuntimeError(
+            "The `keyring` package is required to retrieve secrets. "
+            "Install it via `pip install keyring`."
+        ) from exc
 
     return keyring.get_password(service, username)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 from gabriel.utils import add, subtract, store_secret, get_secret
 import keyring
 from keyring.backend import KeyringBackend
+import builtins
+import pytest
 
 
 def test_add():
@@ -43,3 +45,23 @@ def test_store_and_get_secret():
     keyring.set_keyring(InMemoryKeyring())
     store_secret("service", "user", "hunter2")
     assert get_secret("service", "user") == "hunter2"  # nosec B101
+
+
+@pytest.mark.parametrize(
+    "func,args",
+    [
+        (store_secret, ("svc", "user", "pw")),
+        (get_secret, ("svc", "user")),
+    ],
+)
+def test_keyring_missing(monkeypatch, func, args):
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name == "keyring":
+            raise ModuleNotFoundError
+        return real_import(name, *a, **k)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    with pytest.raises(RuntimeError, match="keyring"):  # nosec B101
+        func(*args)


### PR DESCRIPTION
## Summary
- raise helpful RuntimeError when keyring is missing in secret helpers【F:gabriel/utils.py†L23-L34】【F:gabriel/utils.py†L47-L58】
- add regression tests for missing keyring scenario【F:tests/test_utils.py†L50-L66】
- document missing-keyring behavior for secret storage【F:docs/gabriel/SECRET_STORAGE.md†L24-L27】

## Testing
- `pre-commit run --all-files`【a4bf4e†L1-L9】
- `pytest --cov=gabriel --cov-report=term-missing`【0b574a†L1-L20】

------
https://chatgpt.com/codex/tasks/task_e_6894620f4394832fad6f9e4437ffc4ff