### PR TITLE
🧹 : remove trailing whitespace in tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,8 +27,8 @@ def test_multiply():
 
 def test_multiply_negative_numbers():
     assert multiply(-2, -3) == 6  # nosec B101
-    
-    
+
+
 def test_multiply_with_negative_number():
     assert multiply(-2, 3) == -6  # nosec B101
 


### PR DESCRIPTION
what: strip trailing spaces in test_utils to satisfy flake8
why: lint failed on blank lines with whitespace
how to test: pre-commit run --all-files && pytest --cov=gabriel --cov-report=term-missing
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_689591da9d30832fb93755c7235f8dae