### PR TITLE
Add divide helper with test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ python -m pytest --cov=gabriel --cov-report=term-missing
 Example usage of arithmetic helpers:
 
 ```python
-from gabriel import add, multiply
-print(multiply(add(2, 3), 4))  # 20
+from gabriel import add, multiply, divide
+print(divide(multiply(add(2, 3), 4), 2))  # 10.0
 ```
 
 ### Offline Usage

--- a/docs/gabriel/IMPROVEMENTS.md
+++ b/docs/gabriel/IMPROVEMENTS.md
@@ -11,3 +11,4 @@ This document lists potential enhancements uncovered during a self-audit of the 
 - [x] Document how to run Gabriel completely offline with local models. See [OFFLINE.md](OFFLINE.md).
 - [x] Harden pre-commit hooks to prevent accidental secret leaks.
 - [x] Add `multiply` helper with test coverage.
+- [x] Add `divide` helper with test coverage.

--- a/gabriel/__init__.py
+++ b/gabriel/__init__.py
@@ -1,5 +1,12 @@
 """Core utilities for the Gabriel project."""
 
-from .utils import add, subtract, multiply, store_secret, get_secret
+from .utils import add, subtract, multiply, divide, store_secret, get_secret
 
-__all__ = ["add", "subtract", "multiply", "store_secret", "get_secret"]
+__all__ = [
+    "add",
+    "subtract",
+    "multiply",
+    "divide",
+    "store_secret",
+    "get_secret",
+]

--- a/gabriel/utils.py
+++ b/gabriel/utils.py
@@ -13,6 +13,17 @@ def multiply(a: int, b: int) -> int:
     return a * b
 
 
+def divide(a: int, b: int) -> float:
+    """Return the result of ``a`` divided by ``b``.
+
+    Raises
+    ------
+    ZeroDivisionError
+        If ``b`` is zero.
+    """
+    return a / b
+
+
 def store_secret(service: str, username: str, secret: str) -> None:
     """Store ``secret`` in the system keyring.
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,4 @@
-from gabriel.utils import add, subtract, multiply, store_secret, get_secret
+from gabriel.utils import add, subtract, multiply, divide, store_secret, get_secret
 import keyring
 from keyring.backend import KeyringBackend
 import builtins
@@ -31,6 +31,19 @@ def test_multiply_negative_numbers():
 
 def test_multiply_with_negative_number():
     assert multiply(-2, 3) == -6  # nosec B101
+
+
+def test_divide():
+    assert divide(6, 3) == 2  # nosec B101
+
+
+def test_divide_negative_numbers():
+    assert divide(-6, -3) == 2  # nosec B101
+
+
+def test_divide_by_zero():
+    with pytest.raises(ZeroDivisionError):
+        divide(1, 0)
 
 
 class InMemoryKeyring(KeyringBackend):


### PR DESCRIPTION
## Summary
- add divide arithmetic helper and expose through package
- document divide helper and example usage

## Testing
- `pre-commit run --all-files`
- `pytest --cov=gabriel --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_6896ea50956c832fa651a4fc9a78989e