### PR TITLE
📚: allow Nextcloud in spellcheck dictionary

### DIFF
--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -140,3 +140,5 @@ str
 plaintext
 cpp
 GGUF
+Nextcloud
+nextcloud


### PR DESCRIPTION
## Summary
- allow Nextcloud terms in spellcheck dictionary【F:dict/allow.txt†L143-L144】

## Testing
- `pre-commit run --all-files`【1818b8†L1-L2】
- `pyspelling -c .spellcheck.yaml`【adde31†L1-L2】
- `pytest --cov=gabriel --cov-report=term-missing`【254376†L1-L20】

Refs: #42

------
https://chatgpt.com/codex/tasks/task_e_68970d6e54d8832fa6faafda4e597d73