### PR TITLE
✨ : add delete_secret helper

### DIFF
--- a/docs/gabriel/IMPROVEMENTS.md
+++ b/docs/gabriel/IMPROVEMENTS.md
@@ -11,3 +11,4 @@ This document lists potential enhancements uncovered during a self-audit of the 
 - [x] Document how to run Gabriel completely offline with local models. See [OFFLINE.md](OFFLINE.md).
 - [x] Harden pre-commit hooks to prevent accidental secret leaks.
 - [x] Add `multiply` helper with test coverage.
+- [x] Add `delete_secret` helper to remove stored secrets.

--- a/docs/gabriel/SECRET_STORAGE.md
+++ b/docs/gabriel/SECRET_STORAGE.md
@@ -19,10 +19,14 @@ def save_token(token: str) -> None:
 def load_token() -> str | None:
     """Retrieve token from the system keyring."""
     return keyring.get_password(SERVICE, USERNAME)
+
+def delete_token() -> None:
+    """Remove token from the system keyring."""
+    keyring.delete_password(SERVICE, USERNAME)
 ```
 
 Install `keyring` with `pip install keyring` if it is not already
-available. Gabriel's ``store_secret`` and ``get_secret`` helpers raise a
-``RuntimeError`` when the package is missing. The library encrypts secrets
-using the platform's preferred backend and avoids storing plaintext
-passwords in the repository or environment variables.
+available. Gabriel's ``store_secret``, ``get_secret``, and ``delete_secret`` helpers
+raise a ``RuntimeError`` when the package is missing. The library encrypts secrets
+using the platform's preferred backend and avoids storing plaintext passwords in the
+repository or environment variables.

--- a/gabriel/__init__.py
+++ b/gabriel/__init__.py
@@ -1,6 +1,14 @@
 """Core utilities for the Gabriel project."""
 
-from .utils import add, subtract, multiply, divide, store_secret, get_secret
+from .utils import (
+    add,
+    subtract,
+    multiply,
+    divide,
+    store_secret,
+    get_secret,
+    delete_secret,
+)
 
 __all__ = [
     "add",
@@ -9,4 +17,5 @@ __all__ = [
     "divide",
     "store_secret",
     "get_secret",
+    "delete_secret",
 ]

--- a/gabriel/utils.py
+++ b/gabriel/utils.py
@@ -70,3 +70,16 @@ def get_secret(service: str, username: str) -> str | None:
         ) from exc
 
     return keyring.get_password(service, username)
+
+
+def delete_secret(service: str, username: str) -> None:
+    """Delete a secret from the system keyring."""
+    try:
+        import keyring
+    except ImportError as exc:  # pragma: no cover - exercised via tests
+        raise RuntimeError(
+            "The `keyring` package is required to delete secrets. "
+            "Install it via `pip install keyring`."
+        ) from exc
+
+    keyring.delete_password(service, username)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ from gabriel.utils import (
     divide,
     store_secret,
     get_secret,
+    delete_secret,
 )
 import keyring
 from keyring.backend import KeyringBackend
@@ -69,10 +70,12 @@ class InMemoryKeyring(KeyringBackend):
         self._storage.pop((system, username), None)
 
 
-def test_store_and_get_secret():
+def test_store_get_and_delete_secret():
     keyring.set_keyring(InMemoryKeyring())
     store_secret("service", "user", "hunter2")
     assert get_secret("service", "user") == "hunter2"  # nosec B101
+    delete_secret("service", "user")
+    assert get_secret("service", "user") is None  # nosec B101
 
 
 @pytest.mark.parametrize(
@@ -80,6 +83,7 @@ def test_store_and_get_secret():
     [
         (store_secret, ("svc", "user", "pw")),
         (get_secret, ("svc", "user")),
+        (delete_secret, ("svc", "user")),
     ],
 )
 def test_keyring_missing(monkeypatch, func, args):


### PR DESCRIPTION
## Summary
- add `delete_secret` helper to remove secrets from keyring
- document secret deletion workflow

## Testing
- `pre-commit run --all-files`
- `pytest --cov=gabriel --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_6899153beda4832fbf0383d5fc9aa2bb