### PR TITLE
docs: use local coverage badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Gabriel is an open source "guardian angel" LLM aimed at helping individuals secu
 
 [![Lint & Format](https://img.shields.io/github/actions/workflow/status/futuroptimist/gabriel/.github/workflows/ci.yml?label=lint%20%26%20format)](https://github.com/futuroptimist/gabriel/actions/workflows/ci.yml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/futuroptimist/gabriel/.github/workflows/coverage.yml?label=tests)](https://github.com/futuroptimist/gabriel/actions/workflows/coverage.yml)
-[![Coverage](./coverage.svg)](https://codecov.io/gh/futuroptimist/gabriel)
+[![Coverage](https://raw.githubusercontent.com/futuroptimist/gabriel/main/coverage.svg)](https://codecov.io/gh/futuroptimist/gabriel)
 [![Docs](https://img.shields.io/github/actions/workflow/status/futuroptimist/gabriel/.github/workflows/docs.yml?label=docs&branch=main)](https://github.com/futuroptimist/gabriel/actions/workflows/docs.yml)
 [![License](https://img.shields.io/github/license/futuroptimist/gabriel)](LICENSE)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Gabriel is an open source "guardian angel" LLM aimed at helping individuals secu
 
 [![Lint & Format](https://img.shields.io/github/actions/workflow/status/futuroptimist/gabriel/.github/workflows/ci.yml?label=lint%20%26%20format)](https://github.com/futuroptimist/gabriel/actions/workflows/ci.yml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/futuroptimist/gabriel/.github/workflows/coverage.yml?label=tests)](https://github.com/futuroptimist/gabriel/actions/workflows/coverage.yml)
-[![Coverage](https://codecov.io/gh/futuroptimist/gabriel/branch/main/graph/badge.svg)](https://codecov.io/gh/futuroptimist/gabriel)
+[![Coverage](./coverage.svg)](https://codecov.io/gh/futuroptimist/gabriel)
 [![Docs](https://img.shields.io/github/actions/workflow/status/futuroptimist/gabriel/.github/workflows/docs.yml?label=docs&branch=main)](https://github.com/futuroptimist/gabriel/actions/workflows/docs.yml)
 [![License](https://img.shields.io/github/license/futuroptimist/gabriel)](LICENSE)
 
@@ -103,7 +103,8 @@ We use `AGENTS.md` to outline repository-specific instructions for automated age
 
 The repository includes GitHub Actions workflows for linting, testing, and documentation.
 `flake8` and `bandit` catch style issues and common security mistakes, while coverage results are
-uploaded to [Codecov](https://codecov.io/) after tests run.
+uploaded to [Codecov](https://codecov.io/) and the latest coverage badge is committed to
+[coverage.svg](coverage.svg) after tests run.
 Pre-commit hooks also run `detect-secrets` to prevent accidental credential leaks.
 Dependabot monitors Python dependencies weekly.
 


### PR DESCRIPTION
## Summary
- show coverage using committed badge instead of Codecov's `unknown` badge
- note that CI commits the badge alongside Codecov uploads

## Testing
- `pytest --cov=gabriel --cov-report=term-missing --cov-report=xml`
- `coverage-badge -o coverage.svg -f`
- `pre-commit run --all-files`
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689bc00db968832fb7a0c9a54095e2a1