### PR TITLE
Align style tooling with 100-char lines

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-max-line-length = 88
+max-line-length = 100
 exclude = .git,__pycache__,build,dist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     rev: v2.4.0
     hooks:
       - id: codespell
-        args: ["--ignore-words", "dict/allow.txt", "--skip", "*.lock,*.svg"]
+        args: ["--ignore-words", "dict/allow.txt", "--skip", "*.lock,*.svg,viewer/model-viewer.min.js"]
   - repo: https://github.com/psf/black
     rev: 23.7.0
     hooks:

--- a/docs/gabriel/IMPROVEMENTS.md
+++ b/docs/gabriel/IMPROVEMENTS.md
@@ -22,7 +22,7 @@ This document lists potential enhancements uncovered during a self-audit of the 
       (`gabriel/utils.py`, `tests/test_utils.py`).
 - [ ] Integrate `pip-audit` into pre-commit to detect vulnerable dependencies
       (`.pre-commit-config.yaml`). *Aligns with flywheel best practices.*
-- [ ] Align Black's `line-length` with repo standard of 100 chars (`pyproject.toml`).
+- [x] Align Black's `line-length` with repo standard of 100 chars (`pyproject.toml`).
 - [ ] Support float inputs in arithmetic helpers (`gabriel/utils.py`, `tests/test_utils.py`).
 - [ ] Add CLI entry points for secret management (`pyproject.toml`, `gabriel/utils.py`).
 - [ ] Implement `floordiv` helper with test coverage (`gabriel/utils.py`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 profile = "black"
 
 [tool.black]
-line-length = 88
+line-length = 100
 
 [tool.pytest.ini_options]
 addopts = "--cov=gabriel --cov-report=xml --cov-report=term"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -86,9 +86,7 @@ class InMemoryKeyring(KeyringBackend):
     def get_password(self, system: str, username: str) -> str | None:  # noqa: D401
         return self._storage.get((system, username))
 
-    def set_password(
-        self, system: str, username: str, password: str
-    ) -> None:  # noqa: D401
+    def set_password(self, system: str, username: str, password: str) -> None:  # noqa: D401
         self._storage[(system, username)] = password
 
     def delete_password(self, system: str, username: str) -> None:  # noqa: D401


### PR DESCRIPTION
## Summary
- set Black and Flake8 line length to 100【F:pyproject.toml†L5】【F:.flake8†L2】
- skip bundled viewer script in codespell【F:.pre-commit-config.yaml†L12】
- mark line-length improvement complete【F:docs/gabriel/IMPROVEMENTS.md†L25】

## Testing
- `pre-commit run --all-files`
- `pytest --cov=gabriel --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_689eb5249890832fa4e7d441d1ed7cd2