### PR TITLE
📚: normalize pre-commit in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ The repository includes GitHub Actions workflows for linting, testing, and docum
 `flake8` and `bandit` catch style issues and common security mistakes, while coverage results are
 uploaded to [Codecov](https://codecov.io/) and the latest coverage badge is committed to
 [coverage.svg](coverage.svg) after tests run.
-Pre-commit hooks also run `detect-secrets` to prevent accidental credential leaks.
+pre-commit hooks also run `detect-secrets` to prevent accidental credential leaks.
 Dependabot monitors Python dependencies weekly.
 
 ## FAQ


### PR DESCRIPTION
## Summary
- lowercase pre-commit reference in README for consistency

## Testing
- `pyspelling -c .spellcheck.yaml`
- `pre-commit run --all-files`
- `pytest -q`

Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a00db10a6c832f8f754cb743aa4228