### PR TITLE
🔧 : add lint and test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,11 @@
-.PHONY: preview
+.PHONY: preview lint test
+
 preview:
 	python -m http.server 8000 &
 	python -m webbrowser http://localhost:8000/viewer/
+
+lint:
+	pre-commit run --all-files
+
+test:
+	pytest --cov=gabriel --cov-report=term-missing

--- a/README.md
+++ b/README.md
@@ -45,6 +45,13 @@ Run `pytest` with coverage enabled:
 python -m pytest --cov=gabriel --cov-report=term-missing
 ```
 
+Common tasks are available via the `Makefile`:
+
+```bash
+make lint  # run pre-commit checks
+make test  # run the test suite with coverage
+```
+
 Example usage of arithmetic helpers:
 
 These helpers accept both integers and floats.

--- a/docs/gabriel/IMPROVEMENTS.md
+++ b/docs/gabriel/IMPROVEMENTS.md
@@ -35,7 +35,7 @@ This document lists potential enhancements uncovered during a self-audit of the 
       (`SECURITY.md`). *Aligns with flywheel best practices.*
 - [x] Implement `sqrt` helper with test coverage (`gabriel/utils.py`,
       `tests/test_utils.py`).
-- [ ] Add `lint` and `test` targets to `Makefile` for developer convenience
+- [x] Add `lint` and `test` targets to `Makefile` for developer convenience
       (`Makefile`).
 - [ ] Provide GitHub issue templates for bugs and features
       (`.github/ISSUE_TEMPLATE/bug_report.yml`,


### PR DESCRIPTION
## Summary
- add lint and test make targets for common tasks
- document make targets in README
- mark Makefile targets complete in improvements list

## Testing
- `pre-commit run --all-files`
- `pytest --cov=gabriel --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68a00d42f368832f92cd952fb647358d