### PR TITLE
🛡️ : add SECURITY policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ uploaded to [Codecov](https://codecov.io/) and the latest coverage badge is comm
 Pre-commit hooks also run `detect-secrets` to prevent accidental credential leaks.
 Dependabot monitors Python dependencies weekly.
 
+For vulnerability disclosure guidelines, see [SECURITY.md](SECURITY.md).
+
 ## FAQ
 
 We maintain an evolving list of questions for clarification in [docs/gabriel/FAQ.md](docs/gabriel/FAQ.md). Feel free to add your own or answer existing ones.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security issue, please report it through
+[GitHub Security Advisories](https://github.com/futuroptimist/gabriel/security/advisories/new).
+Do not create a public issue. We will review and respond as soon as possible.
+

--- a/docs/gabriel/IMPROVEMENTS.md
+++ b/docs/gabriel/IMPROVEMENTS.md
@@ -31,7 +31,7 @@ This document lists potential enhancements uncovered during a self-audit of the 
       `.github/workflows/ci.yml`). *Aligns with flywheel best practices.*
 - [ ] Add CodeQL workflow for static application security testing
       (`.github/workflows/codeql.yml`). *Aligns with flywheel best practices.*
-- [ ] Create `SECURITY.md` with vulnerability disclosure guidelines
+- [x] Create `SECURITY.md` with vulnerability disclosure guidelines
       (`SECURITY.md`). *Aligns with flywheel best practices.*
 - [x] Implement `sqrt` helper with test coverage (`gabriel/utils.py`,
       `tests/test_utils.py`).


### PR DESCRIPTION
what: add SECURITY.md and reference in README
why: document vulnerability disclosure guidelines
how to test: pre-commit run --all-files && pytest --cov=gabriel --cov-report=term-missing
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a00d42f368832f92cd952fb647358d