### PR TITLE
🛡️: add pip-audit pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,11 @@ repos:
     hooks:
       - id: bandit
         args: [-r, .]
+  - repo: https://github.com/pypa/pip-audit
+    rev: v2.9.0
+    hooks:
+      - id: pip-audit
+        args: ["--requirement", "requirements.txt"]
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -121,7 +121,8 @@ The repository includes GitHub Actions workflows for linting, testing, and docum
 `flake8` and `bandit` catch style issues and common security mistakes, while coverage results are
 uploaded to [Codecov](https://codecov.io/) and the latest coverage badge is committed to
 [coverage.svg](coverage.svg) after tests run.
-pre-commit hooks also run `detect-secrets` to prevent accidental credential leaks.
+pre-commit hooks also run `detect-secrets` and `pip-audit` to catch secrets and vulnerable
+dependencies.
 Dependabot monitors Python dependencies weekly.
 
 For vulnerability disclosure guidelines, see [SECURITY.md](SECURITY.md).

--- a/docs/gabriel/IMPROVEMENTS.md
+++ b/docs/gabriel/IMPROVEMENTS.md
@@ -20,7 +20,7 @@ This document lists potential enhancements uncovered during a self-audit of the 
       `gabriel/utils.py`).
 - [x] Test `divide` with negative numbers and floats for complete coverage
       (`gabriel/utils.py`, `tests/test_utils.py`).
-- [ ] Integrate `pip-audit` into pre-commit to detect vulnerable dependencies
+- [x] Integrate `pip-audit` into pre-commit to detect vulnerable dependencies
       (`.pre-commit-config.yaml`). *Aligns with flywheel best practices.*
 - [x] Align Black's `line-length` with repo standard of 100 chars (`pyproject.toml`).
 - [x] Support float inputs in arithmetic helpers (`gabriel/utils.py`, `tests/test_utils.py`).


### PR DESCRIPTION
## Summary
- run `pip-audit` in pre-commit to flag vulnerable dependencies
- document new security check and mark improvement complete

## Testing
- `pre-commit run --all-files`
- `pytest --cov=gabriel --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68a57c01c30c832fbb5fcf629fe54a82