### PR TITLE
🧹 : add pip-audit to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,8 @@ repos:
     hooks:
       - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
+  - repo: https://github.com/pypa/pip-audit
+    rev: v2.9.0
+    hooks:
+      - id: pip-audit
+        args: ["-r", "requirements.txt"]

--- a/docs/gabriel/IMPROVEMENTS.md
+++ b/docs/gabriel/IMPROVEMENTS.md
@@ -20,7 +20,7 @@ This document lists potential enhancements uncovered during a self-audit of the 
       `gabriel/utils.py`).
 - [x] Test `divide` with negative numbers and floats for complete coverage
       (`gabriel/utils.py`, `tests/test_utils.py`).
-- [ ] Integrate `pip-audit` into pre-commit to detect vulnerable dependencies
+- [x] Integrate `pip-audit` into pre-commit to detect vulnerable dependencies
       (`.pre-commit-config.yaml`). *Aligns with flywheel best practices.*
 - [x] Align Black's `line-length` with repo standard of 100 chars (`pyproject.toml`).
 - [x] Support float inputs in arithmetic helpers (`gabriel/utils.py`, `tests/test_utils.py`).

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,5 @@ coverage
 coverage-badge
 pytest-cov
 detect-secrets
+pip-audit
 keyring


### PR DESCRIPTION
## Summary
- add pip-audit hook to pre-commit to catch vulnerable dependencies
- mark pip-audit task complete in improvement checklist

## Testing
- `pre-commit run --all-files`
- `pytest --cov=gabriel --cov-report=term-missing`
- `npm run lint` *(fails: missing package.json)*
- `npm run test:ci` *(fails: missing package.json)*
- `git diff --cached | ./scripts/scan-secrets.py` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a57c01c30c832fbb5fcf629fe54a82