### PR TITLE
🛠️ : fix docs spellcheck workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Install spellcheck dictionaries
+        run: sudo apt-get update && sudo apt-get install -y aspell aspell-en
       - name: Set up Python
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,15 +15,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - uses: astral-sh/setup-uv@v1
 
-      # Ensure dictionaries are present
-      - name: Install aspell dictionaries
-        run: sudo apt-get update && sudo apt-get install -y aspell aspell-en
+      - name: Install spellcheck dependencies
+        run: |
+          sudo apt-get update && sudo apt-get install -y aspell aspell-en
+          uv pip install --system pyspelling
 
       - name: Spell check markdown & docs
-        uses: rojopolis/spellcheck-github-actions@0.35.0
-        with:
-          config_path: .spellcheck.yaml
+        run: pyspelling -c .spellcheck.yaml
   linkcheck:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,13 +17,11 @@ jobs:
       - uses: actions/checkout@v3
       - uses: astral-sh/setup-uv@v1
 
-      - name: Install spellcheck dependencies
-        run: |
-          sudo apt-get update && sudo apt-get install -y aspell aspell-en
-          uv pip install --system pyspelling
+      - name: Install spellcheck dictionaries
+        run: sudo apt-get update && sudo apt-get install -y aspell aspell-en
 
       - name: Spell check markdown & docs
-        run: pyspelling -c .spellcheck.yaml
+        run: uvx pyspelling -c .spellcheck.yaml
   linkcheck:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Run `pytest` with coverage enabled:
 python -m pytest --cov=gabriel --cov-report=term-missing
 ```
 
+Spell check documentation:
+
+```bash
+pyspelling -c .spellcheck.yaml
+```
+
 Common tasks are available via the `Makefile`:
 
 ```bash

--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -145,3 +145,4 @@ Nextcloud
 nextcloud
 svg
 WebGL
+pyspelling

--- a/outages/2025-08-20-docs-spellcheck.json
+++ b/outages/2025-08-20-docs-spellcheck.json
@@ -1,0 +1,10 @@
+{
+  "id": "docs-spellcheck-container",
+  "date": "2025-08-20",
+  "component": "docs workflow",
+  "rootCause": "Spell check action ran inside container without aspell dictionaries, causing job failure.",
+  "resolution": "Install aspell and run pyspelling directly in workflow; add test to enforce spell check.",
+  "references": [
+    "https://github.com/futuroptimist/gabriel/actions/runs/17093224104"
+  ]
+}

--- a/outages/README.md
+++ b/outages/README.md
@@ -1,0 +1,15 @@
+# Outage Catalog
+
+Structured archive of past outages. Each outage is stored as a JSON file using the schema in `schema.json`.
+
+File naming: `YYYY-MM-DD-<slug>.json`.
+
+Required fields:
+- `id`: unique identifier
+- `date`: ISO date
+- `component`: affected subsystem
+- `rootCause`: brief description of failure cause
+- `resolution`: how it was fixed
+- `references`: array of related links (PRs, issues, docs)
+
+Agents can parse these files to learn from previous incidents.

--- a/outages/schema.json
+++ b/outages/schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Outage record",
+  "type": "object",
+  "required": ["id", "date", "component", "rootCause", "resolution", "references"],
+  "properties": {
+    "id": { "type": "string" },
+    "date": { "type": "string", "format": "date" },
+    "component": { "type": "string" },
+    "rootCause": { "type": "string" },
+    "resolution": { "type": "string" },
+    "references": {
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ coverage-badge
 pytest-cov
 detect-secrets
 pip-audit
+pyspelling
 keyring

--- a/tests/test_spellcheck.py
+++ b/tests/test_spellcheck.py
@@ -1,13 +1,11 @@
-import subprocess
 from pathlib import Path
+import sys
+
+from pyspelling import __main__ as pyspelling_main
 
 
-def test_spellcheck_docs() -> None:
+def test_spellcheck_docs(monkeypatch) -> None:
     root = Path(__file__).resolve().parents[1]
-    result = subprocess.run(
-        ["pyspelling", "-c", ".spellcheck.yaml"],
-        cwd=root,
-        capture_output=True,
-        text=True,
-    )
-    assert result.returncode == 0, result.stdout + result.stderr
+    monkeypatch.chdir(root)
+    monkeypatch.setattr(sys, "argv", ["pyspelling", "-c", ".spellcheck.yaml"])
+    assert pyspelling_main.main() is False  # nosec B101

--- a/tests/test_spellcheck.py
+++ b/tests/test_spellcheck.py
@@ -1,0 +1,13 @@
+import subprocess
+from pathlib import Path
+
+
+def test_spellcheck_docs() -> None:
+    root = Path(__file__).resolve().parents[1]
+    result = subprocess.run(
+        ["pyspelling", "-c", ".spellcheck.yaml"],
+        cwd=root,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr


### PR DESCRIPTION
what: run pyspelling in docs workflow, add outage log and tests
why: container action lacked aspell dictionaries causing docs job to fail
how to test: pre-commit run --all-files && pytest --cov=gabriel --cov-report=term-missing
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a6c4b00ba8832fa358c1f09f673a69