### PR TITLE
🔐 : add env var fallback for secrets

### DIFF
--- a/docs/gabriel/IMPROVEMENTS.md
+++ b/docs/gabriel/IMPROVEMENTS.md
@@ -65,7 +65,7 @@ This document lists potential enhancements uncovered during a self-audit of the 
       (`viewer/viewer.js`, `.pre-commit-config.yaml`). *Aligns with flywheel best practices.*
 - [ ] Document Docker build and run instructions for local development
       (`docker/Dockerfile`, `README.md`).
-- [ ] Implement environment variable fallback when `keyring` is unavailable
+- [x] Implement environment variable fallback when `keyring` is unavailable
       (`gabriel/utils.py`, `tests/test_utils.py`). *Aligns with flywheel best practices.*
 - [ ] Use `decimal.Decimal` in arithmetic helpers to improve precision
       (`gabriel/utils.py`, `tests/test_utils.py`).

--- a/docs/gabriel/SECRET_STORAGE.md
+++ b/docs/gabriel/SECRET_STORAGE.md
@@ -25,8 +25,10 @@ def delete_token() -> None:
     keyring.delete_password(SERVICE, USERNAME)
 ```
 
-Install `keyring` with `pip install keyring` if it is not already
-available. Gabriel's ``store_secret``, ``get_secret``, and ``delete_secret`` helpers
-raise a ``RuntimeError`` when the package is missing. The library encrypts secrets
-using the platform's preferred backend and avoids storing plaintext passwords in the
-repository or environment variables.
+Install `keyring` with `pip install keyring` if it is not already available.
+When the package is missing, Gabriel's ``store_secret``, ``get_secret``, and
+``delete_secret`` helpers gracefully fall back to environment variables named
+``GABRIEL_SECRET_<SERVICE>_<USERNAME>``. This fallback avoids runtime errors but
+does not provide encryption, so prefer using ``keyring`` whenever possible. The
+library encrypts secrets using the platform's preferred backend and prevents
+storing plaintext passwords in the repository or environment variables.


### PR DESCRIPTION
## Summary
- use env var storage when keyring isn't available
- document secret fallback and tick improvement item

## Testing
- `pre-commit run --all-files`
- `pytest --cov=gabriel --cov-report=term-missing`

------
https://chatgpt.com/codex/tasks/task_e_68a80b10dbdc832fb763354e7ca3495d