### PR TITLE
🧹 : add isort pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,10 @@ repos:
     hooks:
       - id: codespell
         args: ["--ignore-words", "dict/allow.txt", "--skip", "*.lock,*.svg,viewer/model-viewer.min.js"]
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
   - repo: https://github.com/psf/black
     rev: 23.7.0
     hooks:

--- a/docs/gabriel/IMPROVEMENTS.md
+++ b/docs/gabriel/IMPROVEMENTS.md
@@ -44,7 +44,7 @@ This document lists potential enhancements uncovered during a self-audit of the 
       *Aligns with flywheel best practices.*
 - [ ] Add Release Drafter configuration for automated changelog
       (`.github/release-drafter.yml`). *Aligns with flywheel best practices.*
-- [ ] Add `isort` to pre-commit for consistent import ordering
+- [x] Add `isort` to pre-commit for consistent import ordering
       (`.pre-commit-config.yaml`, `pyproject.toml`).
 - [ ] Add Python version matrix in CI to test against 3.10 and 3.11
       (`.github/workflows/coverage.yml`, `.github/workflows/ci.yml`).

--- a/gabriel/__init__.py
+++ b/gabriel/__init__.py
@@ -2,16 +2,16 @@
 
 from .utils import (
     add,
-    subtract,
-    multiply,
+    delete_secret,
     divide,
-    power,
-    modulo,
     floordiv,
+    get_secret,
+    modulo,
+    multiply,
+    power,
     sqrt,
     store_secret,
-    get_secret,
-    delete_secret,
+    subtract,
 )
 
 __all__ = [

--- a/tests/test_spellcheck.py
+++ b/tests/test_spellcheck.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import sys
+from pathlib import Path
 
 from pyspelling import __main__ as pyspelling_main
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,20 +1,22 @@
+import builtins
+
+import keyring
+import pytest
+from keyring.backend import KeyringBackend
+
 from gabriel.utils import (
     add,
-    subtract,
-    multiply,
+    delete_secret,
     divide,
-    power,
-    modulo,
     floordiv,
+    get_secret,
+    modulo,
+    multiply,
+    power,
     sqrt,
     store_secret,
-    get_secret,
-    delete_secret,
+    subtract,
 )
-import keyring
-from keyring.backend import KeyringBackend
-import builtins
-import pytest
 
 
 def test_add():


### PR DESCRIPTION
## Summary
- add isort pre-commit hook for consistent import ordering
- mark isort task as complete

## Testing
- `pre-commit run --all-files`
- `pytest --cov=gabriel --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68a80b10dbdc832fb763354e7ca3495d