### PR TITLE
🛠️ : add mypy pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,11 @@ repos:
     rev: 6.1.0
     hooks:
       - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.5.1
+    hooks:
+      - id: mypy
+        args: ["--ignore-missing-imports"]
   - repo: https://github.com/PyCQA/bandit
     rev: 1.7.7
     hooks:

--- a/docs/gabriel/IMPROVEMENTS.md
+++ b/docs/gabriel/IMPROVEMENTS.md
@@ -12,7 +12,7 @@ This document lists potential enhancements uncovered during a self-audit of the 
 - [x] Harden pre-commit hooks to prevent accidental secret leaks.
 - [x] Add `multiply` helper with test coverage.
 - [x] Add `delete_secret` helper to remove stored secrets.
-- [ ] Integrate `mypy` into pre-commit for static type checks (`.pre-commit-config.yaml`).
+- [x] Integrate `mypy` into pre-commit for static type checks (`.pre-commit-config.yaml`).
       *Aligns with flywheel best practices.*
 - [x] Expand arithmetic helpers with `power` and `modulo` operations
       (`gabriel/utils.py`, `tests/test_utils.py`).

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ coverage
 coverage-badge
 pytest-cov
 detect-secrets
+mypy
 pip-audit
 pyspelling
 keyring


### PR DESCRIPTION
What: integrate mypy into pre-commit for static type checks.
Why: adds typing safety noted in docs/gabriel/IMPROVEMENTS.md.
How: `python -m pre_commit run --all-files`
and `pytest --cov=gabriel --cov-report=term-missing`.
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68a92c5f1b8c832f9470d45a5667538d