### PR TITLE
🛠️ : add .editorconfig for consistent formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# Editor configuration, see https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+max_line_length = 100

--- a/docs/gabriel/IMPROVEMENTS.md
+++ b/docs/gabriel/IMPROVEMENTS.md
@@ -124,7 +124,7 @@ This document lists potential enhancements uncovered during a self-audit of the 
 - [ ] Integrate `commitlint` to enforce Conventional Commits
       (`.pre-commit-config.yaml`, `.github/workflows/ci.yml`).
       *Aligns with flywheel best practices.*
-- [ ] Add `.editorconfig` for consistent editor formatting
+- [x] Add `.editorconfig` for consistent editor formatting
       (`.editorconfig`). *Aligns with flywheel best practices.*
 - [ ] Create `.dockerignore` to reduce Docker build context
       (`.dockerignore`, `docker/Dockerfile`). *Aligns with flywheel best practices.*


### PR DESCRIPTION
Add .editorconfig for editor defaults【F:.editorconfig†L1-L11】
Mark checklist entry complete【F:docs/gabriel/IMPROVEMENTS.md†L127-L128】

what: add repository-wide .editorconfig and mark improvement done
why: ensure consistent formatting across editors
how to test:
- pre-commit run --all-files
- pytest --cov=gabriel --cov-report=term-missing
Refs: docs/gabriel/IMPROVEMENTS.md

------
https://chatgpt.com/codex/tasks/task_e_68aa995c5440832f8dd0a4ae20ac1e8b