### PR TITLE
✨ : add CLI for arithmetic helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ print(floordiv(7, 2))  # 3
 print(sqrt(9))  # 3.0
 ```
 
+### Command-line usage
+
+The same helpers are available via a small CLI:
+
+```bash
+gabriel add 2 3   # 5.0
+gabriel sqrt 9    # 3.0
+```
+
 ### Offline Usage
 
 For fully local inference, see [OFFLINE.md](docs/gabriel/OFFLINE.md).

--- a/docs/gabriel/IMPROVEMENTS.md
+++ b/docs/gabriel/IMPROVEMENTS.md
@@ -16,7 +16,7 @@ This document lists potential enhancements uncovered during a self-audit of the 
       *Aligns with flywheel best practices.*
 - [x] Expand arithmetic helpers with `power` and `modulo` operations
       (`gabriel/utils.py`, `tests/test_utils.py`).
-- [ ] Add CLI entry points for arithmetic utilities (`pyproject.toml`,
+- [x] Add CLI entry points for arithmetic utilities (`pyproject.toml`,
       `gabriel/utils.py`).
 - [x] Test `divide` with negative numbers and floats for complete coverage
       (`gabriel/utils.py`, `tests/test_utils.py`).

--- a/gabriel/utils.py
+++ b/gabriel/utils.py
@@ -1,3 +1,4 @@
+import argparse
 import math
 import os
 import re
@@ -143,3 +144,47 @@ def delete_secret(service: str, username: str) -> None:
         os.environ.pop(_env_secret_key(service, username), None)
     else:
         keyring.delete_password(service, username)
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI for arithmetic helpers.
+
+    Parameters
+    ----------
+    argv:
+        Optional list of arguments. Defaults to :data:`sys.argv`.
+    """
+
+    parser = argparse.ArgumentParser(description="Gabriel arithmetic helpers")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    def two_arg(name: str, func) -> None:  # type: ignore[no-untyped-def]
+        sub = subparsers.add_parser(name, help=f"{name.title()} two numbers")
+        sub.add_argument("a", type=float)
+        sub.add_argument("b", type=float)
+        sub.set_defaults(func=func)
+
+    two_arg("add", add)
+    two_arg("subtract", subtract)
+    two_arg("multiply", multiply)
+    two_arg("divide", divide)
+    two_arg("power", power)
+    two_arg("modulo", modulo)
+    two_arg("floordiv", floordiv)
+
+    sqrt_parser = subparsers.add_parser("sqrt", help="Square root of a number")
+    sqrt_parser.add_argument("a", type=float)
+    sqrt_parser.set_defaults(func=sqrt)
+
+    args = parser.parse_args(argv)
+
+    if args.command == "sqrt":
+        result = args.func(args.a)
+    else:
+        result = args.func(args.a, args.b)
+
+    print(result)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual CLI execution
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
+[project]
+name = "gabriel"
+version = "0.1.0"
+
+[project.scripts]
+gabriel = "gabriel.utils:main"
+
 [tool.isort]
 profile = "black"
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,11 @@
+from gabriel.utils import main
+
+
+def test_cli_add(capsys):
+    main(["add", "2", "3"])
+    assert capsys.readouterr().out.strip() == "5.0"  # nosec B101
+
+
+def test_cli_sqrt(capsys):
+    main(["sqrt", "9"])
+    assert capsys.readouterr().out.strip() == "3.0"  # nosec B101


### PR DESCRIPTION
what: expose arithmetic helpers via gabriel CLI.
why: allow quick command-line calculations.
how to test: pre-commit run --all-files && pytest --cov=gabriel --cov-report=term-missing
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68aa995c5440832f8dd0a4ae20ac1e8b