### PR TITLE
🧮 : add CLI for arithmetic helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ print(floordiv(7, 2))  # 3
 print(sqrt(9))  # 3.0
 ```
 
+These helpers can also be invoked from the command line:
+
+```bash
+python -m gabriel.utils add 2 3
+# 5.0
+```
+
 ### Offline Usage
 
 For fully local inference, see [OFFLINE.md](docs/gabriel/OFFLINE.md).

--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -148,3 +148,4 @@ Syncthing
 WebGL
 pyspelling
 docstring
+utils

--- a/docs/gabriel/IMPROVEMENTS.md
+++ b/docs/gabriel/IMPROVEMENTS.md
@@ -16,7 +16,7 @@ This document lists potential enhancements uncovered during a self-audit of the 
       *Aligns with flywheel best practices.*
 - [x] Expand arithmetic helpers with `power` and `modulo` operations
       (`gabriel/utils.py`, `tests/test_utils.py`).
-- [ ] Add CLI entry points for arithmetic utilities (`pyproject.toml`,
+- [x] Add CLI entry points for arithmetic utilities (`pyproject.toml`,
       `gabriel/utils.py`).
 - [x] Test `divide` with negative numbers and floats for complete coverage
       (`gabriel/utils.py`, `tests/test_utils.py`).

--- a/gabriel/utils.py
+++ b/gabriel/utils.py
@@ -1,3 +1,4 @@
+import argparse
 import math
 import os
 import re
@@ -143,3 +144,39 @@ def delete_secret(service: str, username: str) -> None:
         os.environ.pop(_env_secret_key(service, username), None)
     else:
         keyring.delete_password(service, username)
+
+
+CLI_OPS = {
+    "add": add,
+    "subtract": subtract,
+    "multiply": multiply,
+    "divide": divide,
+    "power": power,
+    "modulo": modulo,
+    "floordiv": floordiv,
+    "sqrt": sqrt,
+}
+
+
+def cli(argv: list[str] | None = None) -> None:
+    """Simple command-line interface for arithmetic helpers."""
+    parser = argparse.ArgumentParser(description="Gabriel arithmetic helpers")
+    parser.add_argument("operation", choices=CLI_OPS.keys())
+    parser.add_argument("a", type=float, help="first operand")
+    parser.add_argument("b", type=float, nargs="?", help="second operand when required")
+    args = parser.parse_args(argv)
+
+    if args.operation == "sqrt":
+        if args.b is not None:
+            parser.error("sqrt takes exactly one argument")
+        result = CLI_OPS["sqrt"](args.a)
+    else:
+        if args.b is None:
+            parser.error(f"{args.operation} requires two arguments")
+        result = CLI_OPS[args.operation](args.a, args.b)
+
+    print(result)
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised in tests
+    cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,11 @@
+[project]
+name = "gabriel"
+version = "0.1.0"
+requires-python = ">=3.10"
+
+[project.scripts]
+gabriel = "gabriel.utils:cli"
+
 [tool.isort]
 profile = "black"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,6 @@
 import builtins
+import subprocess
+import sys
 
 import keyring
 import pytest
@@ -126,6 +128,16 @@ def test_sqrt():
 def test_sqrt_negative():
     with pytest.raises(ValueError):
         sqrt(-1)
+
+
+def test_cli_addition():
+    result = subprocess.run(
+        [sys.executable, "-m", "gabriel.utils", "add", "2", "3"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout.strip() == "5.0"  # nosec B101
 
 
 class InMemoryKeyring(KeyringBackend):


### PR DESCRIPTION
## Summary
- expose arithmetic helpers via new `gabriel` CLI and module entry point
- document and test command-line usage
- mark CLI entry point improvement as complete

## Testing
- `pre-commit run --all-files`
- `pytest --cov=gabriel --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68aa987b3838832f93c56873c6d8b819