### PR TITLE
docs: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# This file helps GitHub automatically assign reviewers.
+# See https://docs.github.com/articles/about-code-owners/
+
+* @futuroptimist

--- a/docs/gabriel/IMPROVEMENTS.md
+++ b/docs/gabriel/IMPROVEMENTS.md
@@ -75,7 +75,7 @@ This document lists potential enhancements uncovered during a self-audit of the 
       (`.github/workflows/ci.yml`, `.pre-commit-config.yaml`). *Aligns with flywheel best practices.*
 - [x] Remove duplicate `pip-audit` entries to streamline pre-commit config
       (`.pre-commit-config.yaml`).
-- [ ] Add `CODEOWNERS` for clear code ownership (`.github/CODEOWNERS`).
+- [x] Add `CODEOWNERS` for clear code ownership (`.github/CODEOWNERS`).
       *Aligns with flywheel best practices.*
 - [ ] Integrate `flake8-docstrings` into pre-commit for docstring style checks
       (`.pre-commit-config.yaml`). *Aligns with flywheel best practices.*


### PR DESCRIPTION
## Summary
- add CODEOWNERS to auto-assign reviewers
- mark CODEOWNERS item complete in improvements list

## Testing
- `pre-commit run --all-files`
- `pytest --cov=gabriel --cov-report=term-missing`


------
https://chatgpt.com/codex/tasks/task_e_68aa987b3838832f93c56873c6d8b819