### PR TITLE
🛠️: upgrade CodeQL action to v3

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: python
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
what: bump CodeQL GitHub Action to v3
why: v2 is deprecated and fails CI runs
how to test: pre-commit run --all-files &&
  pytest --cov=gabriel --cov-report=term-missing
Refs: #0

------
https://chatgpt.com/codex/tasks/task_e_68b0cd3bb1f4832f8e374c8346e47745