### PR TITLE
🛠️ : – fix codeql permissions and log outage

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  security-events: write
 
 jobs:
   analyze:

--- a/outages/2025-09-27-codeql-permissions.json
+++ b/outages/2025-09-27-codeql-permissions.json
@@ -1,0 +1,10 @@
+{
+  "id": "codeql-permissions-incident",
+  "date": "2025-09-27",
+  "component": "codeql workflow",
+  "rootCause": "CodeQL analyze step lacked security-events write permission, so SARIF upload failed with a permissions error.",
+  "resolution": "Added security-events write permission to the CodeQL workflow so analysis results upload correctly.",
+  "references": [
+    "https://github.com/futuroptimist/gabriel/actions/runs/18023853299/job/51287009469"
+  ]
+}


### PR DESCRIPTION
what: grant CodeQL security-events permission and record outage
why: unblock CI CodeQL job by allowing SARIF upload
how to test: pre-commit run --all-files; pytest --cov=gabriel --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68d762c8b5cc832fbc4e08c10cd13041