### PR TITLE
Add automated markdown link checking

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,11 +25,14 @@ jobs:
   linkcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: astral-sh/setup-uv@v1
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - name: Run Markdown link checker
+        uses: lycheeverse/lychee-action@v1.6.1
         with:
-          python-version: '3.x'
-      - run: |
-          uv pip install --system linkchecker
-          linkchecker README.md docs/ || true
+          args: --config lychee.toml README.md docs/
+      - name: Upload lychee report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lychee-report
+          path: lychee/out.md

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ coverage.xml
 # pytest cache
 .pytest_cache/
 .hypothesis/
+.lycheecache/
 
 # Virtual environments
 .venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,11 @@ repos:
     hooks:
       - id: detect-secrets
         args: ['--baseline', '.secrets.baseline']
+  - repo: local
+    hooks:
+      - id: markdown-link-check
+        name: Markdown link checker
+        entry: python scripts/run_lychee.py
+        language: system
+        pass_filenames: false
+        files: ".*\\.(md|MD)$"

--- a/README.md
+++ b/README.md
@@ -180,8 +180,8 @@ The repository includes GitHub Actions workflows for linting, testing, and docum
 `flake8` and `bandit` catch style issues and common security mistakes, while coverage results are
 uploaded to [Codecov](https://codecov.io/) and the latest coverage badge is committed to
 [coverage.svg](coverage.svg) after tests run.
-pre-commit hooks also run `detect-secrets` and `pip-audit` to catch secrets and vulnerable
-dependencies.
+pre-commit hooks also run `detect-secrets`, `pip-audit`, and the `lychee` Markdown link checker to
+catch secrets, vulnerable dependencies, and stale references.
 Dependabot monitors Python dependencies weekly.
 
 For vulnerability disclosure guidelines, see [SECURITY.md](SECURITY.md).

--- a/docs/IMPROVEMENT_CHECKLISTS.md
+++ b/docs/IMPROVEMENT_CHECKLISTS.md
@@ -61,9 +61,9 @@ See [related/nextcloud/IMPROVEMENTS.md](related/nextcloud/IMPROVEMENTS.md).
 - [ ] Review third-party plugins for security issues before enabling them.
 
 ## Syncthing
-- [ ] Serve GUI over HTTPS via reverse proxy ([docs](https://docs.syncthing.net/users/https.html)).
+- [ ] Serve GUI over HTTPS via reverse proxy ([docs](https://docs.syncthing.net/users/reverseproxy.html)).
 - [ ] Disable global discovery and relays on trusted networks
-  ([docs](https://docs.syncthing.net/users/discovery.html)).
+  ([docs](https://docs.syncthing.net/users/stdiscosrv.html)).
 - [ ] Audit IDs and remove unknown connections ([repo](https://github.com/syncthing/syncthing)).
 
 ## VaultWarden

--- a/docs/gabriel/IMPROVEMENTS.md
+++ b/docs/gabriel/IMPROVEMENTS.md
@@ -58,7 +58,7 @@ This document lists potential enhancements uncovered during a self-audit of the 
 - [ ] Enforce minimum test coverage in CI using `--cov-fail-under`
       (`pyproject.toml`, `.github/workflows/coverage.yml`).
       *Aligns with flywheel best practices.*
-- [ ] Add markdown link checker to pre-commit and CI to prevent stale references
+- [x] Add markdown link checker to pre-commit and CI to prevent stale references
       (`.pre-commit-config.yaml`, `.github/workflows/docs.yml`).
       *Aligns with flywheel best practices.*
 - [ ] Add ESLint to pre-commit for viewer JavaScript

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,25 @@
+# Link checking configuration for lychee.
+# Ensures consistent behavior between local pre-commit runs and CI.
+no_progress = true
+verbose = "warn"
+cache = true
+max_cache_age = "1d"
+max_retries = 2
+retry_wait_time = 2
+max_redirects = 10
+max_concurrency = 16
+timeout = 20
+include_fragments = true
+
+# Ignore non-HTTP schemes that are expected in documentation.
+exclude = [
+    "^mailto:",
+    "^tel:",
+    "^geo:",
+    "^sms:",
+]
+
+# Skip generated or instruction templates that intentionally include placeholder links.
+exclude_path = [
+    "^docs/prompts/",
+]

--- a/scripts/run_lychee.py
+++ b/scripts/run_lychee.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Run the lychee link checker with repository defaults."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess  # nosec B404
+import sys
+from pathlib import Path
+
+LYCHEE_VERSION = "0.15.1"
+CONFIG_PATH = Path("lychee.toml")
+
+
+def _ensure_cargo_bin_on_path() -> None:
+    cargo_bin = Path.home() / ".cargo" / "bin"
+    if not cargo_bin.exists():
+        return
+    path = os.environ.get("PATH", "")
+    parts = path.split(os.pathsep) if path else []
+    if str(cargo_bin) not in parts:
+        os.environ["PATH"] = os.pathsep.join([str(cargo_bin), *parts])
+
+
+def _ensure_lychee_installed() -> None:
+    _ensure_cargo_bin_on_path()
+    if shutil.which("lychee"):
+        return
+
+    cargo = shutil.which("cargo")
+    if not cargo:
+        raise SystemExit(
+            "cargo is required to install lychee. Install Rust or add lychee to your PATH."
+        )
+
+    install_cmd = [
+        cargo,
+        "install",
+        "lychee",
+        "--locked",
+        "--version",
+        LYCHEE_VERSION,
+    ]
+    subprocess.run(install_cmd, check=True)  # nosec B603
+    _ensure_cargo_bin_on_path()
+    if not shutil.which("lychee"):
+        raise SystemExit("lychee installation completed but binary not found on PATH")
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run lychee with repository defaults")
+    parser.add_argument("paths", nargs="*", help="Files or directories to scan")
+    return parser.parse_args(argv)
+
+
+def _collect_targets(raw: list[str]) -> list[str]:
+    if raw:
+        targets: list[str] = []
+        for item in raw:
+            path = Path(item)
+            if not path.exists():
+                continue
+            targets.append(str(path))
+        if targets:
+            return sorted(set(targets))
+
+    defaults = ["README.md", "docs"]
+    return [str(Path(item)) for item in defaults if Path(item).exists()]
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    targets = _collect_targets(args.paths)
+    if not targets:
+        print("No markdown paths to scan.")
+        return 0
+
+    _ensure_lychee_installed()
+
+    command = [
+        "lychee",
+        "--config",
+        str(CONFIG_PATH),
+        "--no-progress",
+        "--verbose",
+        "--accept",
+        "200,429",
+        *targets,
+    ]
+
+    try:
+        subprocess.run(command, check=True)  # nosec B603
+    except subprocess.CalledProcessError as exc:
+        return exc.returncode
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_tooling.py
+++ b/tests/test_tooling.py
@@ -1,0 +1,20 @@
+"""Regression tests for repository tooling configuration."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+
+def test_lychee_configuration_exists_and_excludes_prompts() -> None:
+    """Ensure the markdown link checker configuration is present and scoped appropriately."""
+
+    config_path = Path("lychee.toml")
+    assert config_path.exists(), "Expected lychee.toml to exist"  # nosec B101
+
+    content = config_path.read_text(encoding="utf-8")
+    data = tomllib.loads(content)
+
+    assert data.get("no_progress") is True  # nosec B101
+    assert "^docs/prompts/" in data.get("exclude_path", []), "docs prompts should be excluded"  # nosec B101
+    assert "^mailto:" in data.get("exclude", []), "mailto links should remain ignored"  # nosec B101

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -9,7 +9,6 @@ from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 from keyring.backend import KeyringBackend
 
-
 from gabriel.utils import (
     _env_secret_key,
     add,


### PR DESCRIPTION
## Summary
- add lychee config and helper script for markdown link checks
- run lychee in docs workflow and update contributor docs
- fix stale Syncthing links and add tests for the config

## Testing
- pre-commit run --all-files
- pytest --cov=gabriel --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68dc4ee5a170832f9020ffee5ff8a1dc