### PR TITLE
✨ : – Test Python 3.11 in CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,15 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v1
       - name: Install dependencies

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - name: Install spellcheck dictionaries
@@ -14,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: ${{ matrix.python-version }}
       - name: Install uv
         uses: astral-sh/setup-uv@v1
       - name: Install dependencies
@@ -29,7 +32,10 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Commit coverage badge
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: >-
+          matrix.python-version == '3.10' &&
+          github.event_name == 'push' &&
+          github.ref == 'refs/heads/main'
         uses: EndBug/add-and-commit@v9
         with:
           add: coverage.svg

--- a/README.md
+++ b/README.md
@@ -31,9 +31,10 @@ This modular structure keeps responsibilities clear and allows future extensions
 
 ## Getting Started
 
-Gabriel requires Python 3.10 or later. Clone the repository and run the bootstrap
-script to provision a virtual environment, install dependencies, and configure
-pre-commit hooks:
+Gabriel requires Python 3.10 or later. Continuous integration pipelines exercise
+both Python 3.10 and 3.11 to keep compatibility tight. Clone the repository and
+run the bootstrap script to provision a virtual environment, install
+dependencies, and configure pre-commit hooks:
 
 ```bash
 ./scripts/setup.sh

--- a/docs/gabriel/IMPROVEMENTS.md
+++ b/docs/gabriel/IMPROVEMENTS.md
@@ -46,7 +46,7 @@ This document lists potential enhancements uncovered during a self-audit of the 
       (`.github/release-drafter.yml`). *Aligns with flywheel best practices.*
 - [x] Add `isort` to pre-commit for consistent import ordering
       (`.pre-commit-config.yaml`, `pyproject.toml`).
-- [ ] Add Python version matrix in CI to test against 3.10 and 3.11
+- [x] Add Python version matrix in CI to test against 3.10 and 3.11
       (`.github/workflows/coverage.yml`, `.github/workflows/ci.yml`).
       *Aligns with flywheel best practices.*
 - [x] Create setup script referenced in `runbook.yml` for developer onboarding

--- a/gabriel/__init__.py
+++ b/gabriel/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from .arithmetic import add, divide, floordiv, modulo, multiply, power, sqrt, subtract
 from .secrets import delete_secret, get_secret, store_secret
 
+SUPPORTED_PYTHON_VERSIONS = ("3.10", "3.11")
+
 __all__ = [
     "add",
     "subtract",
@@ -17,4 +19,5 @@ __all__ = [
     "store_secret",
     "get_secret",
     "delete_secret",
+    "SUPPORTED_PYTHON_VERSIONS",
 ]

--- a/tests/test_tooling.py
+++ b/tests/test_tooling.py
@@ -46,3 +46,18 @@ def test_ci_workflow_runs_ruff() -> None:
 
     workflow = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
     assert "ruff check" in workflow  # nosec B101
+
+
+def test_workflows_cover_supported_python_versions() -> None:
+    """Ensure CI pipelines exercise every supported Python runtime."""
+
+    from gabriel import SUPPORTED_PYTHON_VERSIONS
+
+    workflow_ci = Path(".github/workflows/ci.yml").read_text(encoding="utf-8")
+    workflow_coverage = Path(".github/workflows/coverage.yml").read_text(encoding="utf-8")
+
+    for version in SUPPORTED_PYTHON_VERSIONS:
+        assert version in workflow_ci, f"CI workflow missing Python {version}"  # nosec B101
+        assert (
+            version in workflow_coverage
+        ), f"Coverage workflow missing Python {version}"  # nosec B101


### PR DESCRIPTION
✨ : –
what:
- add python 3.10/3.11 matrix to ci and coverage workflows
- expose supported runtime metadata and align docs/tests

why:
- verify compatibility across supported runtimes

how to test:
- pre-commit run --all-files
- pytest --cov=gabriel --cov-report=term-missing

Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68dec373c4a0832f97eba7fa2362c208