### PR TITLE
✨ : – enforce docstring linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,7 @@
 [flake8]
 max-line-length = 100
 exclude = .git,__pycache__,build,dist
+extend-select = D
+extend-ignore = D202
+per-file-ignores =
+    tests/*.py: D100,D101,D102,D103,D104,D107

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,8 @@ repos:
     rev: 6.1.0
     hooks:
       - id: flake8
+        additional_dependencies:
+          - flake8-docstrings==1.7.0
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.5.1
     hooks:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ when iterating on lint fixes:
 ruff check .
 ```
 
+Docstring conventions are enforced via ``flake8`` with the ``flake8-docstrings`` plugin. Run
+``flake8`` locally or rely on pre-commit to surface style issues early in development.
+
 Example usage of arithmetic helpers:
 
 These helpers accept both integers and floats and return `decimal.Decimal` results for

--- a/docs/gabriel/IMPROVEMENTS.md
+++ b/docs/gabriel/IMPROVEMENTS.md
@@ -77,8 +77,8 @@ This document lists potential enhancements uncovered during a self-audit of the 
       (`.pre-commit-config.yaml`).
 - [x] Add `CODEOWNERS` for clear code ownership (`.github/CODEOWNERS`).
       *Aligns with flywheel best practices.*
-- [ ] Integrate `flake8-docstrings` into pre-commit for docstring style checks
-      (`.pre-commit-config.yaml`). *Aligns with flywheel best practices.*
+- [x] Integrate `flake8-docstrings` into pre-commit for docstring style checks
+      (`.pre-commit-config.yaml`, `.flake8`). *Aligns with flywheel best practices.*
 - [ ] Test on Linux, macOS, and Windows in CI
       (`.github/workflows/coverage.yml`, `.github/workflows/ci.yml`).
 - [ ] Add markdown linting to pre-commit for doc style consistency

--- a/gabriel/utils.py
+++ b/gabriel/utils.py
@@ -21,6 +21,8 @@ def main(argv: list[str] | None = None) -> None:
     subparsers = parser.add_subparsers(dest="command", required=True)
 
     def add_binary(name: str) -> None:
+        """Register a binary arithmetic command named ``name``."""
+
         sp = subparsers.add_parser(name)
         sp.add_argument("a", type=Decimal)
         sp.add_argument("b", type=Decimal)

--- a/scripts/run_lychee.py
+++ b/scripts/run_lychee.py
@@ -14,6 +14,8 @@ CONFIG_PATH = Path("lychee.toml")
 
 
 def _ensure_cargo_bin_on_path() -> None:
+    """Ensure Cargo's binary directory is available on ``PATH`` when present."""
+
     cargo_bin = Path.home() / ".cargo" / "bin"
     if not cargo_bin.exists():
         return
@@ -24,6 +26,8 @@ def _ensure_cargo_bin_on_path() -> None:
 
 
 def _ensure_lychee_installed() -> None:
+    """Install the ``lychee`` CLI when it is missing from the system."""
+
     _ensure_cargo_bin_on_path()
     if shutil.which("lychee"):
         return
@@ -49,12 +53,16 @@ def _ensure_lychee_installed() -> None:
 
 
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """Parse command-line arguments for link checking."""
+
     parser = argparse.ArgumentParser(description="Run lychee with repository defaults")
     parser.add_argument("paths", nargs="*", help="Files or directories to scan")
     return parser.parse_args(argv)
 
 
 def _collect_targets(raw: list[str]) -> list[str]:
+    """Return canonical paths to scan, falling back to project defaults."""
+
     if raw:
         targets: list[str] = []
         for item in raw:
@@ -70,6 +78,8 @@ def _collect_targets(raw: list[str]) -> list[str]:
 
 
 def main(argv: list[str] | None = None) -> int:
+    """Execute lychee with repository defaults and return the exit status."""
+
     args = _parse_args(argv)
     targets = _collect_targets(args.paths)
     if not targets:

--- a/tests/test_tooling.py
+++ b/tests/test_tooling.py
@@ -41,6 +41,22 @@ def test_pre_commit_configuration_runs_ruff() -> None:
     assert "- id: ruff" in config  # nosec B101
 
 
+def test_pre_commit_configuration_checks_docstrings() -> None:
+    """Ensure flake8 enforces docstring style guidance."""
+
+    config = Path(".pre-commit-config.yaml").read_text(encoding="utf-8")
+    assert "- id: flake8" in config  # nosec B101
+    assert "flake8-docstrings" in config  # nosec B101
+
+
+def test_flake8_configuration_enables_docstring_rules() -> None:
+    """Confirm flake8 is configured to surface docstring violations."""
+
+    config = Path(".flake8").read_text(encoding="utf-8")
+    assert "extend-select = D" in config  # nosec B101
+    assert "tests/*.py: D100,D101,D102,D103,D104,D107" in config  # nosec B101
+
+
 def test_ci_workflow_runs_ruff() -> None:
     """Ensure the CI workflow executes ruff checks."""
 


### PR DESCRIPTION
what: add flake8-docstrings to pre-commit, configure .flake8, and
  document the workflow.
why: align with the improvements checklist and keep docstring style
  consistent across modules.
how to test: python -m pre_commit run --all-files; pytest --cov=gabriel
  --cov-report=term-missing.
Refs: n/a

------
https://chatgpt.com/codex/tasks/task_e_68dec373c4a0832f97eba7fa2362c208