### PR TITLE
✨ : Add VaultWarden audit helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,33 @@ embedded credentials, plaintext HTTP, IP-based hosts, and lookalikes of the supp
 domains. Combine it with Gabriel's secret helpers to build secure intake pipelines
 for inbound phishing reports.
 
+### Audit VaultWarden deployments
+
+Phase 1 of the roadmap calls for tailored advice for self-hosted services such as
+VaultWarden. Use `gabriel.selfhosted.audit_vaultwarden` to surface misconfigurations
+based on the [VaultWarden improvement checklist](docs/IMPROVEMENT_CHECKLISTS.md#vaultwarden).
+
+```python
+from gabriel import VaultWardenConfig, audit_vaultwarden
+
+config = VaultWardenConfig(
+    https_enabled=True,
+    certificate_trusted=False,  # using a self-signed cert in this example
+    encryption_key="CorrectHorseBatteryStaple123!CorrectHorseBatteryStaple",
+    backup_enabled=True,
+    backup_frequency_hours=24,
+    last_restore_verification_days=45,
+    admin_interface_enabled=True,
+    admin_allowed_networks=("192.168.10.0/24",),
+)
+
+for finding in audit_vaultwarden(config):
+    print(f"{finding.severity.upper()} — {finding.message}")
+    print(f"Fix: {finding.remediation}\n")
+```
+
+The helper only reports actionable findings so hardened deployments return an empty list.
+
 ### Offline Usage
 
 For fully local inference, see [OFFLINE.md](docs/gabriel/OFFLINE.md).

--- a/dict/allow.txt
+++ b/dict/allow.txt
@@ -242,3 +242,5 @@ TLDs
 examp
 examp1e
 punycode
+CorrectHorseBatteryStaple
+VaultWardenConfig

--- a/docs/IMPROVEMENT_CHECKLISTS.md
+++ b/docs/IMPROVEMENT_CHECKLISTS.md
@@ -71,3 +71,6 @@ See [related/nextcloud/IMPROVEMENTS.md](related/nextcloud/IMPROVEMENTS.md).
 - [ ] Configure environment variables for strong encryption keys.
 - [ ] Enable automatic database backups and verify restore procedures.
 - [ ] Restrict admin interface access to trusted networks or VPN.
+
+Gabriel now offers `gabriel.selfhosted.audit_vaultwarden` to evaluate these controls and surface
+remediation steps for misconfigurations.

--- a/docs/gabriel/FAQ.md
+++ b/docs/gabriel/FAQ.md
@@ -49,3 +49,7 @@ Feel free to extend this list with additional questions or provide answers in fo
    - A lightweight heuristic scanner in `gabriel.phishing` analyses pasted links for
      punycode, suspicious TLDs, HTTP usage, and lookalike domains. Extend it with
      additional rules as the roadmap advances.
+20. **Can Gabriel audit my VaultWarden deployment?**
+   - Yes. Use `gabriel.selfhosted.audit_vaultwarden` with a
+     `VaultWardenConfig` snapshot to identify gaps from the checklist in
+     [docs/IMPROVEMENT_CHECKLISTS.md](../IMPROVEMENT_CHECKLISTS.md#vaultwarden).

--- a/docs/gabriel/ROADMAP.md
+++ b/docs/gabriel/ROADMAP.md
@@ -12,6 +12,7 @@ This document outlines tentative phases for Gabriel. Dates are aspirational and 
 
 - Collect user-consented configuration data.
 - Suggest improvements for self-hosted services such as PhotoPrism and VaultWarden.
+  (VaultWarden checks ship in `gabriel.selfhosted`.)
 - Integrate token.place for local LLM inference.
 
 ## Phase 2: Personal Knowledge Manager

--- a/gabriel/__init__.py
+++ b/gabriel/__init__.py
@@ -10,6 +10,7 @@ from .phishing import (
     extract_urls,
 )
 from .secrets import delete_secret, get_secret, store_secret
+from .selfhosted import CheckResult, Severity, VaultWardenConfig, audit_vaultwarden
 
 SUPPORTED_PYTHON_VERSIONS = ("3.10", "3.11")
 
@@ -29,5 +30,9 @@ __all__ = [
     "analyze_url",
     "analyze_text_for_phishing",
     "PhishingFinding",
+    "VaultWardenConfig",
+    "CheckResult",
+    "Severity",
+    "audit_vaultwarden",
     "SUPPORTED_PYTHON_VERSIONS",
 ]

--- a/gabriel/selfhosted.py
+++ b/gabriel/selfhosted.py
@@ -66,10 +66,14 @@ def audit_vaultwarden(config: VaultWardenConfig) -> list[CheckResult]:
         findings.append(
             CheckResult(
                 slug="vaultwarden-encryption-key",
-                message="Environment variable `VAULTWARDEN_ADMIN_TOKEN` or master key is weak or unset.",
+                message=(
+                    "Environment variable `VAULTWARDEN_ADMIN_TOKEN` or master key is weak or "
+                    "unset."
+                ),
                 severity="high",
                 remediation=(
-                    "Provision a random token of at least 32 characters mixing cases, numbers, and symbols."
+                    "Provision a random token of at least 32 characters mixing cases, numbers, "
+                    "and symbols."
                 ),
             )
         )

--- a/gabriel/selfhosted.py
+++ b/gabriel/selfhosted.py
@@ -1,0 +1,154 @@
+"""Helpers for auditing self-hosted service configurations."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+Severity = Literal["low", "medium", "high"]
+
+
+@dataclass(frozen=True, slots=True)
+class CheckResult:
+    """Represents a single configuration finding for a service."""
+
+    slug: str
+    message: str
+    severity: Severity
+    remediation: str
+
+
+@dataclass(frozen=True, slots=True)
+class VaultWardenConfig:
+    """Configuration snapshot for a VaultWarden deployment."""
+
+    https_enabled: bool
+    certificate_trusted: bool
+    encryption_key: str | None
+    backup_enabled: bool
+    backup_frequency_hours: int | None
+    last_restore_verification_days: int | None
+    admin_interface_enabled: bool = True
+    admin_allowed_networks: Sequence[str] = ()
+
+
+def audit_vaultwarden(config: VaultWardenConfig) -> list[CheckResult]:
+    """Return security findings for a VaultWarden installation."""
+
+    findings: list[CheckResult] = []
+
+    if not config.https_enabled:
+        findings.append(
+            CheckResult(
+                slug="vaultwarden-https",
+                message="VaultWarden should be served over HTTPS with a trusted certificate.",
+                severity="high",
+                remediation=(
+                    "Configure the reverse proxy or built-in TLS support to enforce HTTPS."
+                ),
+            )
+        )
+    elif not config.certificate_trusted:
+        findings.append(
+            CheckResult(
+                slug="vaultwarden-https",
+                message="HTTPS is enabled but the certificate is not trusted by clients.",
+                severity="medium",
+                remediation=(
+                    "Install a certificate from a trusted CA or a well-known internal PKI."
+                ),
+            )
+        )
+
+    if not _is_strong_secret(config.encryption_key):
+        findings.append(
+            CheckResult(
+                slug="vaultwarden-encryption-key",
+                message="Environment variable `VAULTWARDEN_ADMIN_TOKEN` or master key is weak or unset.",
+                severity="high",
+                remediation=(
+                    "Provision a random token of at least 32 characters mixing cases, numbers, and symbols."
+                ),
+            )
+        )
+
+    if not config.backup_enabled:
+        findings.append(
+            CheckResult(
+                slug="vaultwarden-backups",
+                message="Automatic backups are disabled.",
+                severity="high",
+                remediation="Enable recurring database backups and store them off-host.",
+            )
+        )
+    else:
+        if config.backup_frequency_hours is None or config.backup_frequency_hours > 24:
+            findings.append(
+                CheckResult(
+                    slug="vaultwarden-backups",
+                    message="Backups run infrequently. Aim for at least daily snapshots.",
+                    severity="medium",
+                    remediation="Schedule backups to run every 24 hours or more frequently.",
+                )
+            )
+        if (
+            config.last_restore_verification_days is None
+            or config.last_restore_verification_days > 30
+        ):
+            findings.append(
+                CheckResult(
+                    slug="vaultwarden-restore-test",
+                    message="Restore procedures have not been tested in the last 30 days.",
+                    severity="medium",
+                    remediation="Regularly test restoring from backups to verify integrity.",
+                )
+            )
+
+    if config.admin_interface_enabled:
+        if _is_network_list_open(config.admin_allowed_networks):
+            findings.append(
+                CheckResult(
+                    slug="vaultwarden-admin-network",
+                    message="Admin interface is reachable from untrusted networks.",
+                    severity="high",
+                    remediation="Restrict access to VPN ranges or internal subnets only.",
+                )
+            )
+    return findings
+
+
+def _is_strong_secret(secret: str | None) -> bool:
+    if not secret:
+        return False
+    if len(secret) < 32:
+        return False
+    classes = [
+        re.search(r"[a-z]", secret),
+        re.search(r"[A-Z]", secret),
+        re.search(r"[0-9]", secret),
+        re.search(r"[^A-Za-z0-9]", secret),
+    ]
+    return all(classes)
+
+
+def _is_network_list_open(networks: Iterable[str]) -> bool:
+    normalized = []
+    for network in networks:
+        candidate = network.strip()
+        if not candidate:
+            continue
+        candidate_lower = candidate.lower()
+        normalized.append(candidate_lower)
+        if candidate_lower in {"*", "any", "0.0.0.0/0", "::/0"}:
+            return True
+    return not normalized
+
+
+__all__ = [
+    "CheckResult",
+    "Severity",
+    "VaultWardenConfig",
+    "audit_vaultwarden",
+]

--- a/tests/test_selfhosted.py
+++ b/tests/test_selfhosted.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+
 import pytest
 
-from gabriel.selfhosted import VaultWardenConfig, audit_vaultwarden
+from gabriel.selfhosted import CheckResult, VaultWardenConfig, audit_vaultwarden
 
 
-def _finding_slugs(findings: list[object]) -> set[str]:
-    return {getattr(finding, "slug") for finding in findings}
+def _finding_slugs(findings: Iterable[CheckResult]) -> set[str]:
+    return {finding.slug for finding in findings}
 
 
 def test_audit_vaultwarden_flags_missing_https() -> None:
@@ -48,6 +50,24 @@ def test_audit_vaultwarden_detects_weak_encryption_key() -> None:
     assert "vaultwarden-encryption-key" in slugs  # nosec B101
 
 
+def test_audit_vaultwarden_detects_missing_encryption_key() -> None:
+    config = VaultWardenConfig(
+        https_enabled=True,
+        certificate_trusted=True,
+        encryption_key=None,
+        backup_enabled=True,
+        backup_frequency_hours=12,
+        last_restore_verification_days=10,
+        admin_interface_enabled=True,
+        admin_allowed_networks=("10.0.0.0/8",),
+    )
+
+    findings = audit_vaultwarden(config)
+
+    slugs = _finding_slugs(findings)
+    assert "vaultwarden-encryption-key" in slugs  # nosec B101
+
+
 def test_audit_vaultwarden_warns_on_open_admin_networks() -> None:
     config = VaultWardenConfig(
         https_enabled=True,
@@ -64,6 +84,97 @@ def test_audit_vaultwarden_warns_on_open_admin_networks() -> None:
 
     slugs = _finding_slugs(findings)
     assert "vaultwarden-admin-network" in slugs  # nosec B101
+
+
+def test_audit_vaultwarden_warns_on_untrusted_certificate() -> None:
+    config = VaultWardenConfig(
+        https_enabled=True,
+        certificate_trusted=False,
+        encryption_key="b" * 30 + "Aa1!",
+        backup_enabled=True,
+        backup_frequency_hours=24,
+        last_restore_verification_days=5,
+        admin_interface_enabled=True,
+        admin_allowed_networks=("192.168.10.0/24",),
+    )
+
+    findings = audit_vaultwarden(config)
+
+    slugs = _finding_slugs(findings)
+    assert "vaultwarden-https" in slugs  # nosec B101
+
+
+def test_audit_vaultwarden_warns_when_backups_disabled() -> None:
+    config = VaultWardenConfig(
+        https_enabled=True,
+        certificate_trusted=True,
+        encryption_key="b" * 30 + "Aa1!",
+        backup_enabled=False,
+        backup_frequency_hours=None,
+        last_restore_verification_days=None,
+        admin_interface_enabled=True,
+        admin_allowed_networks=("192.168.10.0/24",),
+    )
+
+    findings = audit_vaultwarden(config)
+
+    slugs = _finding_slugs(findings)
+    assert "vaultwarden-backups" in slugs  # nosec B101
+
+
+def test_audit_vaultwarden_warns_on_backup_cadence_and_restore() -> None:
+    config = VaultWardenConfig(
+        https_enabled=True,
+        certificate_trusted=True,
+        encryption_key="b" * 30 + "Aa1!",
+        backup_enabled=True,
+        backup_frequency_hours=72,
+        last_restore_verification_days=45,
+        admin_interface_enabled=True,
+        admin_allowed_networks=("192.168.10.0/24",),
+    )
+
+    findings = audit_vaultwarden(config)
+
+    slugs = _finding_slugs(findings)
+    assert "vaultwarden-backups" in slugs  # nosec B101
+    assert "vaultwarden-restore-test" in slugs  # nosec B101
+
+
+def test_audit_vaultwarden_warns_when_admin_network_list_empty() -> None:
+    config = VaultWardenConfig(
+        https_enabled=True,
+        certificate_trusted=True,
+        encryption_key="b" * 30 + "Aa1!",
+        backup_enabled=True,
+        backup_frequency_hours=12,
+        last_restore_verification_days=10,
+        admin_interface_enabled=True,
+        admin_allowed_networks=("", "   "),
+    )
+
+    findings = audit_vaultwarden(config)
+
+    slugs = _finding_slugs(findings)
+    assert "vaultwarden-admin-network" in slugs  # nosec B101
+
+
+def test_audit_vaultwarden_skips_admin_checks_when_disabled() -> None:
+    config = VaultWardenConfig(
+        https_enabled=True,
+        certificate_trusted=True,
+        encryption_key="b" * 30 + "Aa1!",
+        backup_enabled=True,
+        backup_frequency_hours=12,
+        last_restore_verification_days=10,
+        admin_interface_enabled=False,
+        admin_allowed_networks=("0.0.0.0/0",),
+    )
+
+    findings = audit_vaultwarden(config)
+
+    slugs = _finding_slugs(findings)
+    assert "vaultwarden-admin-network" not in slugs  # nosec B101
 
 
 @pytest.mark.parametrize(

--- a/tests/test_selfhosted.py
+++ b/tests/test_selfhosted.py
@@ -1,0 +1,90 @@
+# bandit:skip-file
+
+from __future__ import annotations
+
+import pytest
+
+from gabriel.selfhosted import VaultWardenConfig, audit_vaultwarden
+
+
+def _finding_slugs(findings: list[object]) -> set[str]:
+    return {getattr(finding, "slug") for finding in findings}
+
+
+def test_audit_vaultwarden_flags_missing_https() -> None:
+    config = VaultWardenConfig(
+        https_enabled=False,
+        certificate_trusted=False,
+        encryption_key="hunter2",
+        backup_enabled=True,
+        backup_frequency_hours=24,
+        last_restore_verification_days=7,
+        admin_interface_enabled=True,
+        admin_allowed_networks=("192.168.10.0/24",),
+    )
+
+    findings = audit_vaultwarden(config)
+
+    slugs = _finding_slugs(findings)
+    assert "vaultwarden-https" in slugs  # nosec B101 - pytest assertion
+    assert any("HTTPS" in finding.message for finding in findings)  # nosec B101
+
+
+def test_audit_vaultwarden_detects_weak_encryption_key() -> None:
+    config = VaultWardenConfig(
+        https_enabled=True,
+        certificate_trusted=True,
+        encryption_key="short",  # too short
+        backup_enabled=True,
+        backup_frequency_hours=12,
+        last_restore_verification_days=10,
+        admin_interface_enabled=True,
+        admin_allowed_networks=("10.0.0.0/8",),
+    )
+
+    findings = audit_vaultwarden(config)
+
+    slugs = _finding_slugs(findings)
+    assert "vaultwarden-encryption-key" in slugs  # nosec B101
+
+
+def test_audit_vaultwarden_warns_on_open_admin_networks() -> None:
+    config = VaultWardenConfig(
+        https_enabled=True,
+        certificate_trusted=True,
+        encryption_key="b" * 40 + "1!",
+        backup_enabled=True,
+        backup_frequency_hours=24,
+        last_restore_verification_days=5,
+        admin_interface_enabled=True,
+        admin_allowed_networks=("0.0.0.0/0", "::/0"),
+    )
+
+    findings = audit_vaultwarden(config)
+
+    slugs = _finding_slugs(findings)
+    assert "vaultwarden-admin-network" in slugs  # nosec B101
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        "Aa1!" + "b" * 28,
+        "CorrectHorseBatteryStaple123!CorrectHorseBatteryStaple",
+    ],
+)
+def test_audit_vaultwarden_passes_hardened_config(key: str) -> None:
+    config = VaultWardenConfig(
+        https_enabled=True,
+        certificate_trusted=True,
+        encryption_key=key,
+        backup_enabled=True,
+        backup_frequency_hours=12,
+        last_restore_verification_days=7,
+        admin_interface_enabled=True,
+        admin_allowed_networks=("192.168.10.0/24", "10.0.0.0/16"),
+    )
+
+    findings = audit_vaultwarden(config)
+
+    assert findings == []  # nosec B101


### PR DESCRIPTION
What:
- add a VaultWarden configuration auditor with CLI-facing docs
- document the helper across README, FAQ, and roadmap references

Why:
- roadmap calls for per-service hardening guidance starting with VaultWarden

How to test:
- pre-commit run --all-files
- pytest --cov=gabriel --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e1b6495704832f83bf0ab9e69000b1