### PR TITLE
Add Markdown linting hook and CI job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v1
       - name: Install Markdown lint dependencies
-        run: uv pip install --system pymarkdownlnt
+        run: sudo uv pip install --system pymarkdownlnt==0.9.32
       - name: Lint Markdown files
         run: |
           pymarkdown --config .pymarkdown.json scan README.md \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -42,7 +42,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v1
       - name: Install Markdown lint dependencies
-        run: sudo uv pip install --system pymarkdownlnt==0.9.32
+        run: |
+          UV_BIN="$(which uv)"
+          sudo "$UV_BIN" pip install --system pymarkdownlnt==0.9.32
       - name: Lint Markdown files
         run: |
           pymarkdown --config .pymarkdown.json scan README.md \

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,3 +36,14 @@ jobs:
         with:
           name: lychee-report
           path: lychee/out.md
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v1
+      - name: Install Markdown lint dependencies
+        run: uv pip install --system pymarkdownlnt
+      - name: Lint Markdown files
+        run: |
+          pymarkdown --config .pymarkdown.json scan README.md \
+            docs/IMPROVEMENT_CHECKLISTS.md docs/gabriel/IMPROVEMENTS.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,6 +51,15 @@ repos:
         args: ['--baseline', '.secrets.baseline']
   - repo: local
     hooks:
+      - id: markdown-lint
+        name: Markdown lint
+        entry: pymarkdown
+        language: python
+        args: ["--config", ".pymarkdown.json", "scan"]
+        types: [markdown]
+        files: "^(README\\.md|docs/(IMPROVEMENT_CHECKLISTS|gabriel/IMPROVEMENTS)\\.md)$"
+        additional_dependencies:
+          - pymarkdownlnt==0.9.32
       - id: markdown-link-check
         name: Markdown link checker
         entry: python scripts/run_lychee.py

--- a/.pymarkdown.json
+++ b/.pymarkdown.json
@@ -1,0 +1,14 @@
+{
+  "plugins": {
+    "md013": {
+      "line_length": 100,
+      "heading_line_length": 100,
+      "code_block_line_length": 120,
+      "code_blocks": false,
+      "tables": false
+    },
+    "md024": {
+      "allow_different_nesting": true
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Gabriel
 
-Gabriel is an open source "guardian angel" LLM aimed at helping individuals securely navigate the digital world. The project intends to provide actionable security advice, maintain personal knowledge about the user's environment (with their consent), and eventually offer local AI-assisted monitoring. Our guiding principle is to keep user data private and handle AI inference locally. When possible we rely on [token.place](https://github.com/futuroptimist/token.place) for encrypted inference, though a fully offline path using components like `llama-cpp-python` is also supported.
+Gabriel is an open source "guardian angel" LLM aimed at helping individuals securely navigate the
+digital world. The project intends to provide actionable security advice, maintain personal
+knowledge about the user's environment (with their consent), and eventually offer local AI-assisted
+monitoring. Our guiding principle is to keep user data private and handle AI inference locally. When
+possible we rely on [token.place](https://github.com/futuroptimist/token.place) for encrypted
+inference, though a fully offline path using components like `llama-cpp-python` is also supported.
 
 [![Lint & Format](https://img.shields.io/github/actions/workflow/status/futuroptimist/gabriel/.github/workflows/ci.yml?label=lint%20%26%20format)](https://github.com/futuroptimist/gabriel/actions/workflows/ci.yml)
 [![Tests](https://img.shields.io/github/actions/workflow/status/futuroptimist/gabriel/.github/workflows/coverage.yml?label=tests)](https://github.com/futuroptimist/gabriel/actions/workflows/coverage.yml)
@@ -13,28 +18,31 @@ Gabriel is an open source "guardian angel" LLM aimed at helping individuals secu
 
 - Offer community-first, dignity-focused security guidance.
 - Integrate with token.place or fully local inference to avoid cloud exfiltration.
-- Encourage collaboration with [token.place](https://github.com/futuroptimist/token.place) and [sigma](https://github.com/futuroptimist/sigma) as complementary projects.
+- Encourage collaboration with [token.place](https://github.com/futuroptimist/token.place) and
+  [sigma](https://github.com/futuroptimist/sigma) as complementary projects.
 - Provide a gentle on-ramp toward eventual real-world monitoring capabilities.
 
-For a philosophical look at these goals through the lens of the "Sword of Damocles" parable, see [SWORD_OF_DAMOCLES.md](docs/gabriel/SWORD_OF_DAMOCLES.md).
+For a philosophical look at these goals through the lens of the "Sword of Damocles" parable, see
+[SWORD_OF_DAMOCLES.md](docs/gabriel/SWORD_OF_DAMOCLES.md).
 
 ## Architecture Overview
 
 The project is organized into four tentative modules:
 
 1. **Ingestion** – scripts or agents that collect user-consented data.
-2. **Analysis** – LLM-based logic for assessing security posture.
-3. **Notification** – optional alerts or recommendations sent to the user.
-4. **User Interface** – CLI or lightweight UI for interacting with Gabriel.
+1. **Analysis** – LLM-based logic for assessing security posture.
+1. **Notification** – optional alerts or recommendations sent to the user.
+1. **User Interface** – CLI or lightweight UI for interacting with Gabriel.
 
-This modular structure keeps responsibilities clear and allows future extensions like phishing detection or network monitoring. The new phishing heuristics below provide an early look at that roadmap item.
+This modular structure keeps responsibilities clear and allows future extensions like phishing
+detection or network monitoring. The new phishing heuristics below provide an early look at that
+roadmap item.
 
 ## Getting Started
 
-Gabriel requires Python 3.10 or later. Continuous integration pipelines exercise
-both Python 3.10 and 3.11 to keep compatibility tight. Clone the repository and
-run the bootstrap script to provision a virtual environment, install
-dependencies, and configure pre-commit hooks:
+Gabriel requires Python 3.10 or later. Continuous integration pipelines exercise both Python 3.10
+and 3.11 to keep compatibility tight. Clone the repository and run the bootstrap script to provision
+a virtual environment, install dependencies, and configure pre-commit hooks:
 
 ```bash
 ./scripts/setup.sh
@@ -52,13 +60,19 @@ Activate the environment and run `pytest` with coverage enabled:
 python -m pytest --cov=gabriel --cov-report=term-missing
 ```
 
-Pytest is configured to fail the run if coverage dips below 100%, keeping the suite honest as
-the codebase grows.
+Pytest is configured to fail the run if coverage dips below 100%, keeping the suite honest as the
+codebase grows.
 
 Spell check documentation:
 
 ```bash
 pyspelling -c .spellcheck.yaml
+```
+
+Lint Markdown formatting (line width, heading spacing, duplicate headings):
+
+```bash
+pymarkdown --config .pymarkdown.json scan README.md docs
 ```
 
 Scan for hidden zero-width characters:
@@ -74,20 +88,20 @@ make lint  # run pre-commit checks
 make test  # run the test suite with coverage
 ```
 
-Ruff powers the lightweight linting layer used in both pre-commit hooks and CI. Run it directly
-when iterating on lint fixes:
+Ruff powers the lightweight linting layer used in both pre-commit hooks and CI. Run it directly when
+iterating on lint fixes:
 
 ```bash
 ruff check .
 ```
 
-Docstring conventions are enforced via ``flake8`` with the ``flake8-docstrings`` plugin. Run
-``flake8`` locally or rely on pre-commit to surface style issues early in development.
+Docstring conventions are enforced via `flake8` with the `flake8-docstrings` plugin. Run `flake8`
+locally or rely on pre-commit to surface style issues early in development.
 
 Example usage of arithmetic helpers:
 
-These helpers accept both integers and floats and return `decimal.Decimal` results for
-improved precision.
+These helpers accept both integers and floats and return `decimal.Decimal` results for improved
+precision.
 
 ```python
 from decimal import Decimal
@@ -104,9 +118,9 @@ print(floordiv(7, 2))  # 3
 print(sqrt(9))  # 3
 ```
 
-The arithmetic helpers now live in `gabriel.arithmetic`, while secret management utilities
-reside in `gabriel.secrets`. Importing from `gabriel` continues to expose both families for
-backwards compatibility.
+The arithmetic helpers now live in `gabriel.arithmetic`, while secret management utilities reside in
+`gabriel.secrets`. Importing from `gabriel` continues to expose both families for backwards
+compatibility.
 
 Run the helpers from the command line (available as `gabriel` or `gabriel-calc`):
 
@@ -126,15 +140,16 @@ gabriel secret get my-service alice
 gabriel secret delete my-service alice
 ```
 
-If you omit `--secret`, the command reads from standard input or securely prompts
-when attached to a TTY. The retrieval command intentionally avoids printing the
-stored value so it cannot leak via logs; use ``python -c "from gabriel.utils import
-get_secret; print(get_secret('my-service', 'alice'))"`` for programmatic access.
+If you omit `--secret`, the command reads from standard input or securely prompts when attached to a
+TTY. The retrieval command intentionally avoids printing the stored value so it cannot leak via
+logs; use
+`python -c "from gabriel.utils import get_secret; print(get_secret('my-service', 'alice'))"` for
+programmatic access.
 
 ### Detect suspicious links
 
-Gabriel now ships with lightweight phishing detection heuristics for pasted text or
-email bodies. Supply known brand domains to catch close lookalikes.
+Gabriel now ships with lightweight phishing detection heuristics for pasted text or email bodies.
+Supply known brand domains to catch close lookalikes.
 
 ```python
 from gabriel import analyze_text_for_phishing
@@ -145,16 +160,15 @@ for finding in findings:
     print(f"{finding.indicator}: {finding.message} ({finding.severity})")
 ```
 
-The helper inspects each HTTP(S) link for punycode, suspicious top-level domains,
-embedded credentials, plaintext HTTP, IP-based hosts, and lookalikes of the supplied
-domains. Combine it with Gabriel's secret helpers to build secure intake pipelines
-for inbound phishing reports.
+The helper inspects each HTTP(S) link for punycode, suspicious top-level domains, embedded
+credentials, plaintext HTTP, IP-based hosts, and lookalikes of the supplied domains. Combine it with
+Gabriel's secret helpers to build secure intake pipelines for inbound phishing reports.
 
 ### Audit VaultWarden deployments
 
-Phase 1 of the roadmap calls for tailored advice for self-hosted services such as
-VaultWarden. Use `gabriel.selfhosted.audit_vaultwarden` to surface misconfigurations
-based on the [VaultWarden improvement checklist](docs/IMPROVEMENT_CHECKLISTS.md#vaultwarden).
+Phase 1 of the roadmap calls for tailored advice for self-hosted services such as VaultWarden. Use
+`gabriel.selfhosted.audit_vaultwarden` to surface misconfigurations based on the
+[VaultWarden improvement checklist](docs/IMPROVEMENT_CHECKLISTS.md#vaultwarden).
 
 ```python
 from gabriel import VaultWardenConfig, audit_vaultwarden
@@ -187,13 +201,13 @@ For storing secrets in the system keyring, see
 ### Docker builds
 
 The repository ships with a `.dockerignore` file that trims the build context by excluding
-documentation, tests, and other developer-only artifacts. This keeps local Docker builds fast
-and reduces the chance of copying unintended files into the runtime image.
+documentation, tests, and other developer-only artifacts. This keeps local Docker builds fast and
+reduces the chance of copying unintended files into the runtime image.
 
 #### Build the image locally
 
-Use the root `Dockerfile` to produce an image tagged `gabriel`. The build only needs the
-repository checkout; dependencies are installed within the container.
+Use the root `Dockerfile` to produce an image tagged `gabriel`. The build only needs the repository
+checkout; dependencies are installed within the container.
 
 ```bash
 docker build -t gabriel .
@@ -225,95 +239,94 @@ Running in detached mode (`-d`) allows long-lived tasks such as scheduled scans.
 
 ### Runbook & 3D Viewer
 
-This repo now mirrors flywheel's development helpers. `runbook.yml` lists
-typical tasks and `viewer/` hosts a basic `model-viewer` scene. The viewer bundles a
-local copy of the `@google/model-viewer` library to avoid third-party requests,
-and animations start only after pressing **Start Animation**. Launch
-`make preview` to open the viewer locally.
+This repo now mirrors flywheel's development helpers. `runbook.yml` lists typical tasks and
+`viewer/` hosts a basic `model-viewer` scene. The viewer bundles a local copy of the
+`@google/model-viewer` library to avoid third-party requests, and animations start only after
+pressing **Start Animation**. Launch `make preview` to open the viewer locally.
 
 ## Tracked Repositories
 
-The table below summarizes all repositories where we currently maintain
-improvement tasks or security audits.
-Last roster sync: 2025-09-29 05:02 UTC (per Futuroptimist).
-improvement tasks or security audits. Following these links will jump to the
-relevant documentation.
+The table below summarizes all repositories where we currently maintain improvement tasks or
+security audits. Last roster sync: 2025-09-29 05:02 UTC (per Futuroptimist). improvement tasks or
+security audits. Following these links will jump to the relevant documentation.
 
-| Repository | Improvement Docs | Threat Model |
-|------------|------------------|--------------|
-| Gabriel (this repo) | [IMPROVEMENTS.md][gabriel-improve] | [THREAT_MODEL.md][gabriel-threat] |
-| futuroptimist | [IMPROVEMENTS.md][futuroptimist-improve] | [THREAT_MODEL.md][futuroptimist-threat] |
-| token.place | [IMPROVEMENTS.md][token-place-improve] | N/A |
-| DSPACE | [IMPROVEMENTS.md][dspace-improve] | [THREAT_MODEL.md][dspace-threat] |
-| flywheel | [IMPROVEMENTS.md][flywheel-improve] | [THREAT_MODEL.md][flywheel-threat] |
-| f2clipboard | [IMPROVEMENTS.md][f2clipboard-improve] | [THREAT_MODEL.md][f2clipboard-threat] |
-| axel | [IMPROVEMENTS.md][axel-improve] | [THREAT_MODEL.md][axel-threat] |
-| sigma | [IMPROVEMENTS.md][sigma-improve] | [THREAT_MODEL.md][sigma-threat] |
-| gitshelves | [IMPROVEMENTS.md][gitshelves-improve] | [THREAT_MODEL.md][gitshelves-threat] |
-| wove | [IMPROVEMENTS.md][wove-improve] | [THREAT_MODEL.md][wove-threat] |
-| sugarkube | [IMPROVEMENTS.md][sugarkube-improve] | [THREAT_MODEL.md][sugarkube-threat] |
-| pr-reaper | [IMPROVEMENTS.md][pr-reaper-improve] | [THREAT_MODEL.md][pr-reaper-threat] |
-| jobbot3000 | [IMPROVEMENTS.md][jobbot-improve] | [THREAT_MODEL.md][jobbot-threat] |
-| danielsmith.io | [IMPROVEMENTS.md][danielsmith-io-improve] | [THREAT_MODEL.md][danielsmith-io-threat] |
-| Nextcloud | [IMPROVEMENTS.md][nextcloud-improve] | N/A |
-| PhotoPrism | [IMPROVEMENT_CHECKLISTS.md#photoprism][photoprism-improve] | N/A |
-| VaultWarden | [IMPROVEMENT_CHECKLISTS.md#vaultwarden][vaultwarden-improve] | N/A |
-
-[gabriel-improve]: docs/gabriel/IMPROVEMENTS.md
-[gabriel-threat]: docs/gabriel/THREAT_MODEL.md
-[futuroptimist-improve]: docs/related/futuroptimist/IMPROVEMENTS.md
-[futuroptimist-threat]: docs/related/futuroptimist/THREAT_MODEL.md
-[token-place-improve]: docs/related/token_place/IMPROVEMENTS.md
-[dspace-improve]: docs/related/dspace/IMPROVEMENTS.md
-[dspace-threat]: docs/related/dspace/THREAT_MODEL.md
-[flywheel-improve]: docs/related/flywheel/IMPROVEMENTS.md
-[flywheel-threat]: docs/related/flywheel/THREAT_MODEL.md
-[f2clipboard-improve]: docs/related/f2clipboard/IMPROVEMENTS.md
-[f2clipboard-threat]: docs/related/f2clipboard/THREAT_MODEL.md
-[axel-improve]: docs/related/axel/IMPROVEMENTS.md
-[axel-threat]: docs/related/axel/THREAT_MODEL.md
-[sigma-improve]: docs/related/sigma/IMPROVEMENTS.md
-[sigma-threat]: docs/related/sigma/THREAT_MODEL.md
-[gitshelves-improve]: docs/related/gitshelves/IMPROVEMENTS.md
-[gitshelves-threat]: docs/related/gitshelves/THREAT_MODEL.md
-[wove-improve]: docs/related/wove/IMPROVEMENTS.md
-[wove-threat]: docs/related/wove/THREAT_MODEL.md
-[sugarkube-improve]: docs/related/sugarkube/IMPROVEMENTS.md
-[sugarkube-threat]: docs/related/sugarkube/THREAT_MODEL.md
-[pr-reaper-improve]: docs/related/pr-reaper/IMPROVEMENTS.md
-[pr-reaper-threat]: docs/related/pr-reaper/THREAT_MODEL.md
-[jobbot-improve]: docs/related/jobbot3000/IMPROVEMENTS.md
-[jobbot-threat]: docs/related/jobbot3000/THREAT_MODEL.md
-[danielsmith-io-improve]: docs/related/danielsmith_io/IMPROVEMENTS.md
-[danielsmith-io-threat]: docs/related/danielsmith_io/THREAT_MODEL.md
-[nextcloud-improve]: docs/related/nextcloud/IMPROVEMENTS.md
-[photoprism-improve]: docs/IMPROVEMENT_CHECKLISTS.md#photoprism
-[vaultwarden-improve]: docs/IMPROVEMENT_CHECKLISTS.md#vaultwarden
+| Repository | Improvement Docs | Threat Model | |------------|------------------|--------------| |
+Gabriel (this repo) | [IMPROVEMENTS.md][gabriel-improve] | [THREAT_MODEL.md][gabriel-threat] | |
+futuroptimist | [IMPROVEMENTS.md][futuroptimist-improve] | [THREAT_MODEL.md][futuroptimist-threat] |
+| token.place | [IMPROVEMENTS.md][token-place-improve] | N/A | | DSPACE |
+[IMPROVEMENTS.md][dspace-improve] | [THREAT_MODEL.md][dspace-threat] | | flywheel |
+[IMPROVEMENTS.md][flywheel-improve] | [THREAT_MODEL.md][flywheel-threat] | | f2clipboard |
+[IMPROVEMENTS.md][f2clipboard-improve] | [THREAT_MODEL.md][f2clipboard-threat] | | axel |
+[IMPROVEMENTS.md][axel-improve] | [THREAT_MODEL.md][axel-threat] | | sigma |
+[IMPROVEMENTS.md][sigma-improve] | [THREAT_MODEL.md][sigma-threat] | | gitshelves |
+[IMPROVEMENTS.md][gitshelves-improve] | [THREAT_MODEL.md][gitshelves-threat] | | wove |
+[IMPROVEMENTS.md][wove-improve] | [THREAT_MODEL.md][wove-threat] | | sugarkube |
+[IMPROVEMENTS.md][sugarkube-improve] | [THREAT_MODEL.md][sugarkube-threat] | | pr-reaper |
+[IMPROVEMENTS.md][pr-reaper-improve] | [THREAT_MODEL.md][pr-reaper-threat] | | jobbot3000 |
+[IMPROVEMENTS.md][jobbot-improve] | [THREAT_MODEL.md][jobbot-threat] | | danielsmith.io |
+[IMPROVEMENTS.md][danielsmith-io-improve] | [THREAT_MODEL.md][danielsmith-io-threat] | | Nextcloud |
+[IMPROVEMENTS.md][nextcloud-improve] | N/A | | PhotoPrism |
+[IMPROVEMENT_CHECKLISTS.md#photoprism][photoprism-improve] | N/A | | VaultWarden |
+[IMPROVEMENT_CHECKLISTS.md#vaultwarden][vaultwarden-improve] | N/A |
 
 ## Roadmap
 
-See [docs/gabriel/ROADMAP.md](docs/gabriel/ROADMAP.md) for a more detailed roadmap. Early milestones include:
+See [docs/gabriel/ROADMAP.md](docs/gabriel/ROADMAP.md) for a more detailed roadmap. Early milestones
+include:
 
 1. Establishing repository guidelines and a base documentation structure.
-2. Collecting security best practices for self-hosted services.
-3. Prototyping local LLM inference through token.place.
+1. Collecting security best practices for self-hosted services.
+1. Prototyping local LLM inference through token.place.
 
 ## Contributing
 
-We use `AGENTS.md` to outline repository-specific instructions for automated agents. Additional contributor guidelines live in [CONTRIBUTING.md](CONTRIBUTING.md). Please read them before opening pull requests.
+We use `AGENTS.md` to outline repository-specific instructions for automated agents. Additional
+contributor guidelines live in [CONTRIBUTING.md](CONTRIBUTING.md). Please read them before opening
+pull requests.
 
 ## CI & Security
 
-The repository includes GitHub Actions workflows for linting, testing, and documentation.
-`flake8` and `bandit` catch style issues and common security mistakes, while coverage results are
-uploaded to [Codecov](https://codecov.io/) and the latest coverage badge is committed to
-[coverage.svg](coverage.svg) after tests run.
-pre-commit hooks also run `detect-secrets`, `pip-audit`, and the `lychee` Markdown link checker to
-catch secrets, vulnerable dependencies, and stale references.
-Dependabot monitors Python dependencies weekly.
+The repository includes GitHub Actions workflows for linting, testing, and documentation. `flake8`
+and `bandit` catch style issues and common security mistakes, while coverage results are uploaded to
+[Codecov](https://codecov.io/) and the latest coverage badge is committed to
+[coverage.svg](coverage.svg) after tests run. pre-commit hooks also run `detect-secrets`,
+`pip-audit`, and the `lychee` Markdown link checker to catch secrets, vulnerable dependencies, and
+stale references. Dependabot monitors Python dependencies weekly.
 
 For vulnerability disclosure guidelines, see [SECURITY.md](SECURITY.md).
 
 ## FAQ
 
-We maintain an evolving list of questions for clarification in [docs/gabriel/FAQ.md](docs/gabriel/FAQ.md). Feel free to add your own or answer existing ones.
+We maintain an evolving list of questions for clarification in
+[docs/gabriel/FAQ.md](docs/gabriel/FAQ.md). Feel free to add your own or answer existing ones.
+
+[axel-improve]: docs/related/axel/IMPROVEMENTS.md
+[axel-threat]: docs/related/axel/THREAT_MODEL.md
+[danielsmith-io-improve]: docs/related/danielsmith_io/IMPROVEMENTS.md
+[danielsmith-io-threat]: docs/related/danielsmith_io/THREAT_MODEL.md
+[dspace-improve]: docs/related/dspace/IMPROVEMENTS.md
+[dspace-threat]: docs/related/dspace/THREAT_MODEL.md
+[f2clipboard-improve]: docs/related/f2clipboard/IMPROVEMENTS.md
+[f2clipboard-threat]: docs/related/f2clipboard/THREAT_MODEL.md
+[flywheel-improve]: docs/related/flywheel/IMPROVEMENTS.md
+[flywheel-threat]: docs/related/flywheel/THREAT_MODEL.md
+[futuroptimist-improve]: docs/related/futuroptimist/IMPROVEMENTS.md
+[futuroptimist-threat]: docs/related/futuroptimist/THREAT_MODEL.md
+[gabriel-improve]: docs/gabriel/IMPROVEMENTS.md
+[gabriel-threat]: docs/gabriel/THREAT_MODEL.md
+[gitshelves-improve]: docs/related/gitshelves/IMPROVEMENTS.md
+[gitshelves-threat]: docs/related/gitshelves/THREAT_MODEL.md
+[jobbot-improve]: docs/related/jobbot3000/IMPROVEMENTS.md
+[jobbot-threat]: docs/related/jobbot3000/THREAT_MODEL.md
+[nextcloud-improve]: docs/related/nextcloud/IMPROVEMENTS.md
+[photoprism-improve]: docs/IMPROVEMENT_CHECKLISTS.md#photoprism
+[pr-reaper-improve]: docs/related/pr-reaper/IMPROVEMENTS.md
+[pr-reaper-threat]: docs/related/pr-reaper/THREAT_MODEL.md
+[sigma-improve]: docs/related/sigma/IMPROVEMENTS.md
+[sigma-threat]: docs/related/sigma/THREAT_MODEL.md
+[sugarkube-improve]: docs/related/sugarkube/IMPROVEMENTS.md
+[sugarkube-threat]: docs/related/sugarkube/THREAT_MODEL.md
+[token-place-improve]: docs/related/token_place/IMPROVEMENTS.md
+[vaultwarden-improve]: docs/IMPROVEMENT_CHECKLISTS.md#vaultwarden
+[wove-improve]: docs/related/wove/IMPROVEMENTS.md
+[wove-threat]: docs/related/wove/THREAT_MODEL.md

--- a/docs/IMPROVEMENT_CHECKLISTS.md
+++ b/docs/IMPROVEMENT_CHECKLISTS.md
@@ -1,72 +1,87 @@
 # Improvement Checklists
 
-This page consolidates security and feature enhancements for repositories related to Gabriel.
-Where a dedicated document exists, follow the link below. Otherwise tasks are listed inline.
+This page consolidates security and feature enhancements for repositories related to Gabriel. Where
+a dedicated document exists, follow the link below. Otherwise tasks are listed inline.
 
 ## Gabriel (self)
+
 See [gabriel/IMPROVEMENTS.md](gabriel/IMPROVEMENTS.md).
 
 ## futuroptimist
+
 See [related/futuroptimist/IMPROVEMENTS.md](related/futuroptimist/IMPROVEMENTS.md).
 
 ## token.place
+
 See [related/token_place/IMPROVEMENTS.md](related/token_place/IMPROVEMENTS.md).
 
 ## DSPACE
+
 See [related/dspace/IMPROVEMENTS.md](related/dspace/IMPROVEMENTS.md).
 
 ## flywheel
+
 See [related/flywheel/IMPROVEMENTS.md](related/flywheel/IMPROVEMENTS.md).
 
 ## f2clipboard
+
 See [related/f2clipboard/IMPROVEMENTS.md](related/f2clipboard/IMPROVEMENTS.md).
 
 ## axel
+
 See [related/axel/IMPROVEMENTS.md](related/axel/IMPROVEMENTS.md).
 
 ## sigma
+
 See [related/sigma/IMPROVEMENTS.md](related/sigma/IMPROVEMENTS.md).
 
 ## gitshelves
+
 See [related/gitshelves/IMPROVEMENTS.md](related/gitshelves/IMPROVEMENTS.md).
 
 ## wove
+
 See [related/wove/IMPROVEMENTS.md](related/wove/IMPROVEMENTS.md).
 
 ## sugarkube
+
 See [related/sugarkube/IMPROVEMENTS.md](related/sugarkube/IMPROVEMENTS.md).
 
 ## pr-reaper
+
 See [related/pr-reaper/IMPROVEMENTS.md](related/pr-reaper/IMPROVEMENTS.md).
 
 ## jobbot3000
+
 See [related/jobbot3000/IMPROVEMENTS.md](related/jobbot3000/IMPROVEMENTS.md).
 
 ## Docker
+
 - [ ] Run the daemon in rootless mode to drop root privileges ([docs][docker-rootless]).
 - [ ] Enable Docker Content Trust to verify signed images ([docs][docker-trust]).
 - [ ] Use user ID remapping to isolate container file systems ([docs][docker-userns]).
 
-[docker-rootless]: https://docs.docker.com/engine/security/rootless/
-[docker-trust]: https://docs.docker.com/engine/security/trust/
-[docker-userns]: https://docs.docker.com/engine/security/userns-remap/
-
 ## Nextcloud
+
 See [related/nextcloud/IMPROVEMENTS.md](related/nextcloud/IMPROVEMENTS.md).
 
 ## PhotoPrism
+
 - [ ] Enable HTTPS by default and use strong admin credentials.
 - [ ] Store images outside of the application container with strict permissions.
 - [ ] Set up scheduled backups to a secure location.
 - [ ] Review third-party plugins for security issues before enabling them.
 
 ## Syncthing
-- [ ] Serve GUI over HTTPS via reverse proxy ([docs](https://docs.syncthing.net/users/reverseproxy.html)).
+
+- [ ] Serve GUI over HTTPS via reverse proxy
+  ([docs](https://docs.syncthing.net/users/reverseproxy.html)).
 - [ ] Disable global discovery and relays on trusted networks
   ([docs](https://docs.syncthing.net/users/stdiscosrv.html)).
 - [ ] Audit IDs and remove unknown connections ([repo](https://github.com/syncthing/syncthing)).
 
 ## VaultWarden
+
 - [ ] Serve the interface over HTTPS with a trusted certificate.
 - [ ] Configure environment variables for strong encryption keys.
 - [ ] Enable automatic database backups and verify restore procedures.
@@ -74,3 +89,7 @@ See [related/nextcloud/IMPROVEMENTS.md](related/nextcloud/IMPROVEMENTS.md).
 
 Gabriel now offers `gabriel.selfhosted.audit_vaultwarden` to evaluate these controls and surface
 remediation steps for misconfigurations.
+
+[docker-rootless]: https://docs.docker.com/engine/security/rootless/
+[docker-trust]: https://docs.docker.com/engine/security/trust/
+[docker-userns]: https://docs.docker.com/engine/security/userns-remap/

--- a/docs/gabriel/IMPROVEMENTS.md
+++ b/docs/gabriel/IMPROVEMENTS.md
@@ -7,131 +7,117 @@ This document lists potential enhancements uncovered during a self-audit of the 
 - [x] Implement `flake8` and `bandit` in CI to catch style and security issues.
 - [x] Expand unit tests beyond the simple `add` function.
 - [x] Add unit tests for negative numbers in arithmetic helpers.
-- [x] Provide examples of encrypted secret storage using `keyring` ([SECRET_STORAGE.md](SECRET_STORAGE.md)).
-- [x] Document how to run Gabriel completely offline with local models. See [OFFLINE.md](OFFLINE.md).
+- [x] Provide examples of encrypted secret storage using `keyring`
+  ([SECRET_STORAGE.md](SECRET_STORAGE.md)).
+- [x] Document how to run Gabriel completely offline with local models. See
+  [OFFLINE.md](OFFLINE.md).
 - [x] Harden pre-commit hooks to prevent accidental secret leaks.
 - [x] Add `multiply` helper with test coverage.
 - [x] Add `delete_secret` helper to remove stored secrets.
-- [x] Integrate `mypy` into pre-commit for static type checks (`.pre-commit-config.yaml`).
-      *Aligns with flywheel best practices.*
-- [x] Expand arithmetic helpers with `power` and `modulo` operations
-      (`gabriel/utils.py`, `tests/test_utils.py`).
-- [x] Add CLI entry points for arithmetic utilities (`pyproject.toml`,
-      `gabriel/utils.py`).
-- [x] Test `divide` with negative numbers and floats for complete coverage
-      (`gabriel/utils.py`, `tests/test_utils.py`).
+- [x] Integrate `mypy` into pre-commit for static type checks (`.pre-commit-config.yaml`). *Aligns
+  with flywheel best practices.*
+- [x] Expand arithmetic helpers with `power` and `modulo` operations (`gabriel/utils.py`,
+  `tests/test_utils.py`).
+- [x] Add CLI entry points for arithmetic utilities (`pyproject.toml`, `gabriel/utils.py`).
+- [x] Test `divide` with negative numbers and floats for complete coverage (`gabriel/utils.py`,
+  `tests/test_utils.py`).
 - [x] Integrate `pip-audit` into pre-commit to detect vulnerable dependencies
-      (`.pre-commit-config.yaml`). *Aligns with flywheel best practices.*
+  (`.pre-commit-config.yaml`). *Aligns with flywheel best practices.*
 - [x] Align Black's `line-length` with repo standard of 100 chars (`pyproject.toml`).
 - [x] Support float inputs in arithmetic helpers (`gabriel/utils.py`, `tests/test_utils.py`).
 - [x] Add CLI entry points for secret management (`pyproject.toml`, `gabriel/utils.py`).
-- [x] Implement `floordiv` helper with test coverage (`gabriel/utils.py`,
-      `tests/test_utils.py`).
+- [x] Implement `floordiv` helper with test coverage (`gabriel/utils.py`, `tests/test_utils.py`).
 - [x] Integrate `ruff` linter into pre-commit and CI (`.pre-commit-config.yaml`,
-      `.github/workflows/ci.yml`). *Aligns with flywheel best practices.*
-- [x] Prototype phishing detection heuristics for suspicious links
-      (`gabriel/phishing.py`, `tests/test_phishing.py`).
-- [x] Add CodeQL workflow for static application security testing
-      (`.github/workflows/codeql.yml`). *Aligns with flywheel best practices.*
-- [x] Create `SECURITY.md` with vulnerability disclosure guidelines
-      (`SECURITY.md`). *Aligns with flywheel best practices.*
-- [x] Implement `sqrt` helper with test coverage (`gabriel/utils.py`,
-      `tests/test_utils.py`).
-- [x] Add `lint` and `test` targets to `Makefile` for developer convenience
-      (`Makefile`).
-- [x] Provide GitHub issue templates for bugs and features
-      (`.github/ISSUE_TEMPLATE/bug_report.yml`,
-      `.github/ISSUE_TEMPLATE/feature_request.yml`).
-- [ ] Expand Dependabot to monitor GitHub Actions updates (`.github/dependabot.yml`).
-      *Aligns with flywheel best practices.*
-- [ ] Add Release Drafter configuration for automated changelog
-      (`.github/release-drafter.yml`). *Aligns with flywheel best practices.*
-- [x] Add `isort` to pre-commit for consistent import ordering
-      (`.pre-commit-config.yaml`, `pyproject.toml`).
+  `.github/workflows/ci.yml`). *Aligns with flywheel best practices.*
+- [x] Prototype phishing detection heuristics for suspicious links (`gabriel/phishing.py`,
+  `tests/test_phishing.py`).
+- [x] Add CodeQL workflow for static application security testing (`.github/workflows/codeql.yml`).
+  *Aligns with flywheel best practices.*
+- [x] Create `SECURITY.md` with vulnerability disclosure guidelines (`SECURITY.md`). *Aligns with
+  flywheel best practices.*
+- [x] Implement `sqrt` helper with test coverage (`gabriel/utils.py`, `tests/test_utils.py`).
+- [x] Add `lint` and `test` targets to `Makefile` for developer convenience (`Makefile`).
+- [x] Provide GitHub issue templates for bugs and features (`.github/ISSUE_TEMPLATE/bug_report.yml`,
+  `.github/ISSUE_TEMPLATE/feature_request.yml`).
+- [ ] Expand Dependabot to monitor GitHub Actions updates (`.github/dependabot.yml`). *Aligns with
+  flywheel best practices.*
+- [ ] Add Release Drafter configuration for automated changelog (`.github/release-drafter.yml`).
+  *Aligns with flywheel best practices.*
+- [x] Add `isort` to pre-commit for consistent import ordering (`.pre-commit-config.yaml`,
+  `pyproject.toml`).
 - [x] Add Python version matrix in CI to test against 3.10 and 3.11
-      (`.github/workflows/coverage.yml`, `.github/workflows/ci.yml`).
-      *Aligns with flywheel best practices.*
-- [x] Create setup script referenced in `runbook.yml` for developer onboarding
-      (`runbook.yml`, `scripts/setup.sh`).
-- [x] Scan for zero-width characters and hidden text via pre-commit hook
-      (`.pre-commit-config.yaml`, `docs/gabriel/THREAT_MODEL.md`, `gabriel/text.py`).
-      *Aligns with flywheel best practices.*
+  (`.github/workflows/coverage.yml`, `.github/workflows/ci.yml`). *Aligns with flywheel best
+  practices.*
+- [x] Create setup script referenced in `runbook.yml` for developer onboarding (`runbook.yml`,
+  `scripts/setup.sh`).
+- [x] Scan for zero-width characters and hidden text via pre-commit hook (`.pre-commit-config.yaml`,
+  `docs/gabriel/THREAT_MODEL.md`, `gabriel/text.py`). *Aligns with flywheel best practices.*
 - [ ] Add Jest unit tests for the WebGL viewer (`viewer/viewer.js`).
-- [x] Enforce minimum test coverage in CI using `--cov-fail-under`
-      (`pyproject.toml`, `.github/workflows/coverage.yml`).
-      *Aligns with flywheel best practices.*
+- [x] Enforce minimum test coverage in CI using `--cov-fail-under` (`pyproject.toml`,
+  `.github/workflows/coverage.yml`). *Aligns with flywheel best practices.*
 - [x] Add markdown link checker to pre-commit and CI to prevent stale references
-      (`.pre-commit-config.yaml`, `.github/workflows/docs.yml`).
-      *Aligns with flywheel best practices.*
-- [ ] Add ESLint to pre-commit for viewer JavaScript
-      (`viewer/viewer.js`, `.pre-commit-config.yaml`). *Aligns with flywheel best practices.*
-- [x] Document Docker build and run instructions for local development
-      (`docker/Dockerfile`, `README.md`).
-- [x] Implement environment variable fallback when `keyring` is unavailable
-      (`gabriel/utils.py`, `tests/test_utils.py`). *Aligns with flywheel best practices.*
-- [x] Use `decimal.Decimal` in arithmetic helpers to improve precision
-      (`gabriel/utils.py`, `tests/test_utils.py`).
+  (`.pre-commit-config.yaml`, `.github/workflows/docs.yml`). *Aligns with flywheel best practices.*
+- [ ] Add ESLint to pre-commit for viewer JavaScript (`viewer/viewer.js`,
+  `.pre-commit-config.yaml`). *Aligns with flywheel best practices.*
+- [x] Document Docker build and run instructions for local development (`docker/Dockerfile`,
+  `README.md`).
+- [x] Implement environment variable fallback when `keyring` is unavailable (`gabriel/utils.py`,
+  `tests/test_utils.py`). *Aligns with flywheel best practices.*
+- [x] Use `decimal.Decimal` in arithmetic helpers to improve precision (`gabriel/utils.py`,
+  `tests/test_utils.py`).
 - [ ] Enable multi-architecture Docker builds for `amd64` and `arm64`
-      (`.github/workflows/docker.yml`). *Aligns with flywheel best practices.*
-- [ ] Run `pre-commit` hooks in CI to ensure local and CI checks match
-      (`.github/workflows/ci.yml`, `.pre-commit-config.yaml`). *Aligns with flywheel best practices.*
+  (`.github/workflows/docker.yml`). *Aligns with flywheel best practices.*
+- [ ] Run `pre-commit` hooks in CI to ensure local and CI checks match (`.github/workflows/ci.yml`,
+  `.pre-commit-config.yaml`). *Aligns with flywheel best practices.*
 - [x] Remove duplicate `pip-audit` entries to streamline pre-commit config
-      (`.pre-commit-config.yaml`).
-- [x] Add `CODEOWNERS` for clear code ownership (`.github/CODEOWNERS`).
-      *Aligns with flywheel best practices.*
+  (`.pre-commit-config.yaml`).
+- [x] Add `CODEOWNERS` for clear code ownership (`.github/CODEOWNERS`). *Aligns with flywheel best
+  practices.*
 - [x] Integrate `flake8-docstrings` into pre-commit for docstring style checks
-      (`.pre-commit-config.yaml`, `.flake8`). *Aligns with flywheel best practices.*
-- [ ] Test on Linux, macOS, and Windows in CI
-      (`.github/workflows/coverage.yml`, `.github/workflows/ci.yml`).
-- [ ] Add markdown linting to pre-commit for doc style consistency
-      (`.pre-commit-config.yaml`, `docs/**`).
-      *Aligns with flywheel best practices.*
-- [ ] Enforce docstring conventions using `pydocstyle` or similar
-      (`.pre-commit-config.yaml`, `gabriel/utils.py`).
-      *Aligns with flywheel best practices.*
-- [ ] Cache Python dependencies in CI workflows to improve build times
-      (`.github/workflows/ci.yml`, `.github/workflows/coverage.yml`,
-      `.github/workflows/docs.yml`).
-      *Aligns with flywheel best practices.*
-- [ ] Scan Docker images for vulnerabilities during builds
-      (`.github/workflows/docker.yml`). *Aligns with flywheel best practices.*
-- [ ] Format viewer assets with Prettier via pre-commit
-      (`viewer/viewer.js`, `.pre-commit-config.yaml`).
+  (`.pre-commit-config.yaml`, `.flake8`). *Aligns with flywheel best practices.*
+- [ ] Test on Linux, macOS, and Windows in CI (`.github/workflows/coverage.yml`,
+  `.github/workflows/ci.yml`).
+- [x] Add markdown linting to pre-commit for doc style consistency (`.pre-commit-config.yaml`,
+  `docs/**`). *Aligns with flywheel best practices.*
+- [ ] Enforce docstring conventions using `pydocstyle` or similar (`.pre-commit-config.yaml`,
+  `gabriel/utils.py`). *Aligns with flywheel best practices.*
+- [ ] Cache Python dependencies in CI workflows to improve build times (`.github/workflows/ci.yml`,
+  `.github/workflows/coverage.yml`, `.github/workflows/docs.yml`). *Aligns with flywheel best
+  practices.*
+- [ ] Scan Docker images for vulnerabilities during builds (`.github/workflows/docker.yml`). *Aligns
+  with flywheel best practices.*
+- [ ] Format viewer assets with Prettier via pre-commit (`viewer/viewer.js`,
+  `.pre-commit-config.yaml`).
 - [ ] Add pull request template to standardize contributions (`.github/PULL_REQUEST_TEMPLATE.md`).
-      *Aligns with flywheel best practices.*
-- [ ] Generate API docs with Sphinx and publish under `docs/`
-      (`gabriel/utils.py`, `docs/`). *Aligns with flywheel best practices.*
-- [ ] Scan Docker images for vulnerabilities in CI using `trivy`
-      (`docker/Dockerfile`, `.github/workflows/docker.yml`). *Aligns with flywheel best practices.*
+  *Aligns with flywheel best practices.*
+- [ ] Generate API docs with Sphinx and publish under `docs/` (`gabriel/utils.py`, `docs/`). *Aligns
+  with flywheel best practices.*
+- [ ] Scan Docker images for vulnerabilities in CI using `trivy` (`docker/Dockerfile`,
+  `.github/workflows/docker.yml`). *Aligns with flywheel best practices.*
 - [ ] Define project metadata in `pyproject.toml` for packaging and distribution (`pyproject.toml`).
-      *Aligns with flywheel best practices.*
-- [ ] Cache dependencies in GitHub Actions to speed up CI
-      (`.github/workflows/ci.yml`, `.github/workflows/coverage.yml`).
-- [ ] Add Markdown linting to pre-commit and CI (`.pre-commit-config.yaml`, `.github/workflows/docs.yml`).
-- [ ] Integrate `trufflehog` secret scanning into pre-commit and CI
-      (`.pre-commit-config.yaml`, `.github/workflows/ci.yml`).
-      *Aligns with flywheel best practices.*
+  *Aligns with flywheel best practices.*
+- [ ] Cache dependencies in GitHub Actions to speed up CI (`.github/workflows/ci.yml`,
+  `.github/workflows/coverage.yml`).
+- [x] Add Markdown linting to pre-commit and CI (`.pre-commit-config.yaml`,
+  `.github/workflows/docs.yml`).
+- [ ] Integrate `trufflehog` secret scanning into pre-commit and CI (`.pre-commit-config.yaml`,
+  `.github/workflows/ci.yml`). *Aligns with flywheel best practices.*
 - [x] Add property-based tests using `hypothesis` for arithmetic and secret helpers
-      (`tests/test_utils.py`, `requirements.txt`, `gabriel/utils.py`).
-      *Aligns with flywheel best practices.*
-- [ ] Generate API documentation with `mkdocs` and publish to GitHub Pages
-      (`docs/`, `pyproject.toml`, `.github/workflows/docs.yml`).
-      *Aligns with flywheel best practices.*
-- [ ] Expand Dependabot to monitor Docker base image updates
-      (`.github/dependabot.yml`, `docker/Dockerfile`).
-      *Aligns with flywheel best practices.*
-- [ ] Document usage and setup steps for the WebGL viewer
-      (`viewer/viewer.js`, `README.md`).
-      *Aligns with flywheel best practices.*
-- [ ] Integrate `commitlint` to enforce Conventional Commits
-      (`.pre-commit-config.yaml`, `.github/workflows/ci.yml`).
-      *Aligns with flywheel best practices.*
-- [x] Add `.editorconfig` for consistent editor formatting
-      (`.editorconfig`). *Aligns with flywheel best practices.*
-- [x] Create `.dockerignore` to reduce Docker build context
-      (`.dockerignore`, `docker/Dockerfile`). *Aligns with flywheel best practices.*
-- [x] Split arithmetic and secret helpers into dedicated modules
-      (`gabriel/utils.py`, `tests/test_utils.py`).
-- [ ] Integrate `semgrep` static analysis into pre-commit and CI
-      (`.pre-commit-config.yaml`, `.github/workflows/ci.yml`).
-      *Aligns with flywheel best practices.*
+  (`tests/test_utils.py`, `requirements.txt`, `gabriel/utils.py`). *Aligns with flywheel best
+  practices.*
+- [ ] Generate API documentation with `mkdocs` and publish to GitHub Pages (`docs/`,
+  `pyproject.toml`, `.github/workflows/docs.yml`). *Aligns with flywheel best practices.*
+- [ ] Expand Dependabot to monitor Docker base image updates (`.github/dependabot.yml`,
+  `docker/Dockerfile`). *Aligns with flywheel best practices.*
+- [ ] Document usage and setup steps for the WebGL viewer (`viewer/viewer.js`, `README.md`). *Aligns
+  with flywheel best practices.*
+- [ ] Integrate `commitlint` to enforce Conventional Commits (`.pre-commit-config.yaml`,
+  `.github/workflows/ci.yml`). *Aligns with flywheel best practices.*
+- [x] Add `.editorconfig` for consistent editor formatting (`.editorconfig`). *Aligns with flywheel
+  best practices.*
+- [x] Create `.dockerignore` to reduce Docker build context (`.dockerignore`, `docker/Dockerfile`).
+  *Aligns with flywheel best practices.*
+- [x] Split arithmetic and secret helpers into dedicated modules (`gabriel/utils.py`,
+  `tests/test_utils.py`).
+- [ ] Integrate `semgrep` static analysis into pre-commit and CI (`.pre-commit-config.yaml`,
+  `.github/workflows/ci.yml`). *Aligns with flywheel best practices.*

--- a/tests/test_markdown_config.py
+++ b/tests/test_markdown_config.py
@@ -1,0 +1,18 @@
+"""Tests for the repository's Markdown lint configuration."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_markdown_line_length_budget() -> None:
+    """Ensure the Markdown lint configuration enforces the repo's 100 char limit."""
+    config_path = Path(__file__).resolve().parents[1] / ".pymarkdown.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    md013 = config["plugins"]["md013"]
+    assert md013["line_length"] == 100  # nosec: unit tests rely on assertions
+    assert md013["heading_line_length"] == 100  # nosec: unit tests rely on assertions
+    assert (
+        md013["code_block_line_length"] >= 100
+    )  # nosec: documenting rationale for wide code blocks


### PR DESCRIPTION
## Summary
- add a pymarkdown-based lint hook scoped to README and improvement docs
- configure lint settings, document usage, and cover them with a sanity test
- wire the markdown lint job into docs CI and reflow affected docs

## Testing
- pre-commit run --all-files
- pytest --cov=gabriel --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68e40c4d6d6c832f8445131123e50f5a