### PR TITLE
feat: add allowlisted fetch proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,32 @@ print(safe)
 # Summarize the notes below.
 ```
 
+### Route outbound HTTP requests through an allow-listed proxy
+
+Gabriel's threat model recommends routing outbound HTTP through a proxy that
+verifies destinations before sending requests. Use
+``gabriel.security.AllowlistedFetchProxy`` to enforce domain allow-lists and
+capture an audit log of every request:
+
+```python
+from gabriel.security import AllowlistedFetchProxy
+
+proxy = AllowlistedFetchProxy(["api.example.com", "*.trusted.test"])
+result = proxy.fetch(
+    "https://api.example.com/v1/status",
+    headers={"User-Agent": "gabriel"},
+)
+print(result.status_code)
+print(result.headers["content-type"])
+
+for entry in proxy.audit_log:
+    print(entry.url, entry.allowed, entry.status_code)
+```
+
+By default the proxy requires HTTPS, rejects destinations that are not
+explicitly allow-listed, and records timing, status codes, and failure reasons
+for downstream analysis.
+
 ### Organize security notes into a knowledge store
 
 Phase 2 of the roadmap introduces a personal knowledge manager that keeps security

--- a/docs/security/llm_agent_threat_model.md
+++ b/docs/security/llm_agent_threat_model.md
@@ -85,7 +85,8 @@ agentic coding workflows, regardless of deployment environment.
 
 - Maintain an **allow-listed command registry** (YAML) that maps tasks → permitted tools.
 - Enforce **tool-call validators** that check arguments against regex policies and rate limits.
-- Route outbound HTTP via an **allow-listed fetch proxy** with domain verification and logging.
+- Route outbound HTTP via an **allow-listed fetch proxy** with domain verification and logging
+  (see `gabriel.security.AllowlistedFetchProxy`).
 - Require **human approval** for escalation requests (e.g., installing new packages).
 
 ### Mitigation: CI/CD & Repo Hardening

--- a/gabriel/security/__init__.py
+++ b/gabriel/security/__init__.py
@@ -1,8 +1,18 @@
 """Security utilities for Gabriel agents."""
 
+from .fetch_proxy import (
+    AllowlistedFetchProxy,
+    FetchLogEntry,
+    FetchNotAllowed,
+    FetchResult,
+)
 from .policies.egress_control import EgressControlPolicy, EgressPolicyViolation
 
 __all__ = [
+    "AllowlistedFetchProxy",
     "EgressControlPolicy",
     "EgressPolicyViolation",
+    "FetchLogEntry",
+    "FetchNotAllowed",
+    "FetchResult",
 ]

--- a/gabriel/security/fetch_proxy.py
+++ b/gabriel/security/fetch_proxy.py
@@ -1,0 +1,248 @@
+"""Allow-listed HTTP fetch proxy with domain verification and auditing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import logging
+from typing import Callable, Iterable, Mapping, MutableSequence, Sequence
+from urllib.error import URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+import time
+
+__all__ = [
+    "AllowlistedFetchProxy",
+    "FetchLogEntry",
+    "FetchNotAllowed",
+    "FetchResult",
+]
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class FetchResult:
+    """Result returned by :class:`AllowlistedFetchProxy` fetch operations."""
+
+    url: str
+    status_code: int
+    headers: Mapping[str, str]
+    body: bytes
+
+
+@dataclass(slots=True, frozen=True)
+class FetchLogEntry:
+    """Audit log entry describing a proxy fetch attempt."""
+
+    timestamp: datetime
+    url: str
+    method: str
+    allowed: bool
+    status_code: int | None
+    duration: float | None
+    reason: str | None = None
+
+
+class FetchNotAllowed(RuntimeError):
+    """Raised when a URL violates the fetch proxy security policy."""
+
+
+@dataclass(slots=True, frozen=True)
+class _DomainRule:
+    host: str
+    match_subdomains: bool
+    port: int | None
+
+    def matches(self, host: str, port: int | None) -> bool:
+        """Return ``True`` when ``host`` and ``port`` match this rule."""
+        host = host.lower()
+        if self.port is not None and self.port != (port or self.port):
+            return False
+        if host == self.host:
+            return True
+        return self.match_subdomains and host.endswith(f".{self.host}")
+
+
+Transport = Callable[[Request, float | None], FetchResult]
+
+
+def _default_transport(request: Request, timeout: float | None = None) -> FetchResult:
+    with urlopen(request, timeout=timeout) as response:  # nosec: B310 - domain is verified ahead of time
+        body = response.read()
+        status = response.getcode() or 0
+        headers = {key: value for key, value in response.headers.items()}
+    return FetchResult(url=request.full_url, status_code=status, headers=headers, body=body)
+
+
+class AllowlistedFetchProxy:
+    """Proxy that guards outbound HTTP(S) requests behind a domain allow-list."""
+
+    def __init__(
+        self,
+        allowed_domains: Iterable[str],
+        *,
+        require_https: bool = True,
+        transport: Transport | None = None,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        self._rules: Sequence[_DomainRule] = tuple(self._parse_rule(rule) for rule in allowed_domains)
+        if not self._rules:
+            raise ValueError("allowed_domains must contain at least one hostname")
+        self.require_https = require_https
+        self._transport = transport or _default_transport
+        self._logger = logger or _LOGGER
+        self._audit_log: MutableSequence[FetchLogEntry] = []
+
+    @property
+    def audit_log(self) -> Sequence[FetchLogEntry]:
+        """Return immutable view of recorded fetch attempts."""
+        return tuple(self._audit_log)
+
+    def clear_audit_log(self) -> None:
+        """Remove all recorded audit entries."""
+        self._audit_log.clear()
+
+    def fetch(
+        self,
+        url: str,
+        *,
+        method: str = "GET",
+        headers: Mapping[str, str] | None = None,
+        data: bytes | None = None,
+        timeout: float | None = None,
+    ) -> FetchResult:
+        """Fetch a URL after enforcing protocol and domain policies."""
+
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"}:
+            raise FetchNotAllowed("Only http:// or https:// URLs are permitted")
+        if self.require_https and parsed.scheme != "https":
+            raise FetchNotAllowed("HTTPS is required for outbound requests")
+        host = parsed.hostname
+        if host is None:
+            raise FetchNotAllowed("URL is missing a hostname")
+        port = self._effective_port(parsed.scheme, parsed.port)
+        if not self._is_allowed(host, port):
+            host_display = f"{host}:{port}" if port is not None else host
+            reason = f"Host {host_display} is not allow-listed"
+            entry = FetchLogEntry(
+                timestamp=datetime.now(tz=timezone.utc),
+                url=url,
+                method=method.upper(),
+                allowed=False,
+                status_code=None,
+                duration=None,
+                reason=reason,
+            )
+            self._audit_log.append(entry)
+            self._logger.warning("Denied outbound request to %s: %s", url, entry.reason)
+            raise FetchNotAllowed(entry.reason)
+
+        request = Request(url, data=data, method=method.upper())
+        if headers:
+            for key, value in headers.items():
+                request.add_header(key, value)
+
+        start = time.perf_counter()
+        try:
+            result = self._transport(request, timeout)
+        except URLError as exc:  # pragma: no cover - urllib specific branch, hits in integration tests
+            duration = time.perf_counter() - start
+            entry = FetchLogEntry(
+                timestamp=datetime.now(tz=timezone.utc),
+                url=url,
+                method=method.upper(),
+                allowed=True,
+                status_code=None,
+                duration=duration,
+                reason=str(exc.reason or exc),
+            )
+            self._audit_log.append(entry)
+            self._logger.error("Fetch to %s failed: %s", url, entry.reason)
+            raise
+        except Exception as exc:
+            duration = time.perf_counter() - start
+            entry = FetchLogEntry(
+                timestamp=datetime.now(tz=timezone.utc),
+                url=url,
+                method=method.upper(),
+                allowed=True,
+                status_code=None,
+                duration=duration,
+                reason=str(exc),
+            )
+            self._audit_log.append(entry)
+            self._logger.error("Fetch to %s failed: %s", url, entry.reason)
+            raise
+        else:
+            duration = time.perf_counter() - start
+            entry = FetchLogEntry(
+                timestamp=datetime.now(tz=timezone.utc),
+                url=result.url,
+                method=method.upper(),
+                allowed=True,
+                status_code=result.status_code,
+                duration=duration,
+                reason=None,
+            )
+            self._audit_log.append(entry)
+            self._logger.info(
+                "Fetched %s %s status=%s duration=%.3fs",
+                method.upper(),
+                result.url,
+                result.status_code,
+                duration,
+            )
+            return result
+
+    def _is_allowed(self, host: str, port: int | None) -> bool:
+        normalized_host = host.lower().rstrip(".")
+        for rule in self._rules:
+            if rule.matches(normalized_host, port):
+                return True
+        return False
+
+    def _parse_rule(self, rule: str) -> _DomainRule:
+        text = rule.strip()
+        if not text:
+            raise ValueError("Allow-list entries must be non-empty")
+        match_subdomains = False
+        port: int | None = None
+        host_text = text
+        if "://" in host_text:
+            parsed = urlparse(host_text)
+            if parsed.scheme and parsed.scheme not in {"http", "https"}:
+                raise ValueError(f"Unsupported scheme in allow-list entry: {text}")
+            host_text = parsed.netloc
+            port = parsed.port
+        if host_text.startswith("*."):
+            match_subdomains = True
+            host_text = host_text[2:]
+        elif host_text.startswith("."):
+            match_subdomains = True
+            host_text = host_text.lstrip(".")
+        if ":" in host_text:
+            host_part, port_part = host_text.rsplit(":", 1)
+            host_text = host_part
+            if not port_part:
+                raise ValueError(f"Invalid port in allow-list entry: {text}")
+            try:
+                port = int(port_part)
+            except ValueError as exc:  # pragma: no cover - validation guard
+                raise ValueError(f"Invalid port in allow-list entry: {text}") from exc
+        host_text = host_text.strip().lower().rstrip(".")
+        if not host_text or any(ch in host_text for ch in " /?#"):
+            raise ValueError(f"Invalid hostname in allow-list entry: {text}")
+        return _DomainRule(host=host_text, match_subdomains=match_subdomains, port=port)
+
+    @staticmethod
+    def _effective_port(scheme: str, port: int | None) -> int | None:
+        if port is not None:
+            return port
+        if scheme == "http":
+            return 80
+        if scheme == "https":
+            return 443
+        return None

--- a/tests/test_fetch_proxy.py
+++ b/tests/test_fetch_proxy.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from types import SimpleNamespace
+from typing import Mapping
+
+import pytest
+
+from gabriel.security import (
+    AllowlistedFetchProxy,
+    FetchLogEntry,
+    FetchNotAllowed,
+    FetchResult,
+)
+
+
+@dataclass(slots=True)
+class StubTransport:
+    response: FetchResult
+    should_raise: Exception | None = None
+    requests: list[tuple[str, Mapping[str, str], bytes | None, float | None]] = field(
+        init=False, default_factory=list
+    )
+
+    def __call__(self, request, timeout):  # noqa: D401 - protocol compatible callable
+        if self.should_raise is not None:
+            raise self.should_raise
+        headers = {key: value for key, value in request.header_items()}
+        self.requests.append((request.full_url, headers, request.data, timeout))
+        return self.response
+
+
+def make_response(url: str) -> FetchResult:
+    return FetchResult(url=url, status_code=200, headers={"content-type": "text/plain"}, body=b"ok")
+
+
+def test_fetch_proxy_allows_allowlisted_domain() -> None:
+    transport = StubTransport(response=make_response("https://example.com/resource"))
+    proxy = AllowlistedFetchProxy(["example.com"], transport=transport)
+
+    result = proxy.fetch(
+        "https://example.com/resource",
+        headers={"User-Agent": "Gabriel"},
+        timeout=1.5,
+    )
+
+    assert result.body == b"ok"
+    assert transport.requests[0][0] == "https://example.com/resource"
+    header_snapshot = {key.lower(): value for key, value in transport.requests[0][1].items()}
+    assert header_snapshot["user-agent"] == "Gabriel"
+    assert transport.requests[0][2:] == (None, 1.5)
+    assert len(proxy.audit_log) == 1
+    entry = proxy.audit_log[0]
+    assert entry.allowed is True
+    assert entry.status_code == 200
+    assert entry.reason is None
+
+
+def test_fetch_proxy_denies_unlisted_domain() -> None:
+    proxy = AllowlistedFetchProxy(["example.com"])
+
+    with pytest.raises(FetchNotAllowed) as excinfo:
+        proxy.fetch("https://evil.test")
+
+    assert "not allow-listed" in str(excinfo.value)
+    assert len(proxy.audit_log) == 1
+    entry = proxy.audit_log[0]
+    assert entry.allowed is False
+    assert entry.status_code is None
+
+
+def test_fetch_proxy_requires_https() -> None:
+    proxy = AllowlistedFetchProxy(["example.com"], require_https=True)
+
+    with pytest.raises(FetchNotAllowed):
+        proxy.fetch("http://example.com/insecure")
+
+    assert proxy.audit_log == ()
+
+
+def test_fetch_proxy_allows_http_when_disabled() -> None:
+    transport = StubTransport(response=make_response("http://example.com/check"))
+    proxy = AllowlistedFetchProxy(["example.com"], require_https=False, transport=transport)
+
+    proxy.fetch("http://example.com/check")
+
+    assert proxy.audit_log[0].allowed is True
+
+
+def test_fetch_proxy_wildcard_support() -> None:
+    transport = StubTransport(response=make_response("https://api.example.com/data"))
+    proxy = AllowlistedFetchProxy(["*.example.com"], transport=transport)
+
+    proxy.fetch("https://sub.api.example.com/data")
+
+    assert proxy.audit_log[0].allowed is True
+    assert transport.requests[0][0] == "https://sub.api.example.com/data"
+
+
+def test_fetch_proxy_leading_dot_support() -> None:
+    transport = StubTransport(response=make_response("https://beta.example.net/data"))
+    proxy = AllowlistedFetchProxy([".example.net"], transport=transport)
+
+    proxy.fetch("https://api.example.net/data")
+
+    assert proxy.audit_log[0].allowed is True
+
+
+def test_fetch_proxy_requires_matching_port() -> None:
+    transport = StubTransport(response=make_response("https://api.example.com:8443/health"))
+    proxy = AllowlistedFetchProxy(["https://api.example.com:8443"], transport=transport)
+
+    proxy.fetch("https://api.example.com:8443/health")
+
+    assert proxy.audit_log[0].allowed is True
+
+    with pytest.raises(FetchNotAllowed):
+        proxy.fetch("https://api.example.com:443/health")
+
+
+def test_fetch_proxy_reports_transport_errors() -> None:
+    error = RuntimeError("network down")
+    transport = StubTransport(response=make_response("https://example.com"), should_raise=error)
+    proxy = AllowlistedFetchProxy(["example.com"], transport=transport)
+
+    with pytest.raises(RuntimeError):
+        proxy.fetch("https://example.com")
+
+    assert len(proxy.audit_log) == 1
+    entry = proxy.audit_log[0]
+    assert isinstance(entry, FetchLogEntry)
+    assert entry.allowed is True
+    assert entry.reason == "network down"
+    assert entry.status_code is None
+
+
+def test_fetch_proxy_clear_audit_log() -> None:
+    transport = StubTransport(response=make_response("https://example.com"))
+    proxy = AllowlistedFetchProxy(["example.com"], transport=transport)
+    proxy.fetch("https://example.com")
+    assert proxy.audit_log
+    proxy.clear_audit_log()
+    assert proxy.audit_log == ()
+
+
+def test_fetch_proxy_rejects_empty_allowlist() -> None:
+    with pytest.raises(ValueError):
+        AllowlistedFetchProxy([])
+
+
+def test_fetch_proxy_rejects_invalid_scheme() -> None:
+    with pytest.raises(ValueError):
+        AllowlistedFetchProxy(["ftp://example.com"])
+
+
+def test_fetch_proxy_rejects_blank_entry() -> None:
+    with pytest.raises(ValueError):
+        AllowlistedFetchProxy(["   "])
+
+
+def test_fetch_proxy_rejects_invalid_port_format() -> None:
+    with pytest.raises(ValueError):
+        AllowlistedFetchProxy(["example.com:"])
+
+
+def test_fetch_proxy_rejects_invalid_hostname_characters() -> None:
+    with pytest.raises(ValueError):
+        AllowlistedFetchProxy(["exa mple.com"])
+
+
+def test_fetch_proxy_rejects_non_http_scheme_at_fetch_time() -> None:
+    proxy = AllowlistedFetchProxy(["example.com"])
+
+    with pytest.raises(FetchNotAllowed):
+        proxy.fetch("mailto:user@example.com")
+
+
+def test_fetch_proxy_rejects_missing_hostname() -> None:
+    proxy = AllowlistedFetchProxy(["example.com"])
+
+    with pytest.raises(FetchNotAllowed):
+        proxy.fetch("https:///missing-host")
+
+
+def test_fetch_proxy_default_transport(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured = SimpleNamespace(request=None, timeout=None)
+
+    class DummyResponse:
+        def __init__(self) -> None:
+            self.headers = {"content-type": "application/json"}
+
+        def __enter__(self) -> "DummyResponse":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        def read(self) -> bytes:
+            return b"{}"
+
+        def getcode(self) -> int:
+            return 204
+
+    def fake_urlopen(request, timeout=None):
+        captured.request = request
+        captured.timeout = timeout
+        return DummyResponse()
+
+    monkeypatch.setattr("gabriel.security.fetch_proxy.urlopen", fake_urlopen)
+
+    proxy = AllowlistedFetchProxy(["example.com"])
+    result = proxy.fetch("https://example.com/status", timeout=2.0)
+
+    assert result.status_code == 204
+    assert result.body == b"{}"
+    assert captured.request.full_url == "https://example.com/status"
+    assert captured.timeout == 2.0
+    assert proxy.audit_log[0].status_code == 204
+
+
+def test_effective_port_handles_unknown_scheme() -> None:
+    assert AllowlistedFetchProxy._effective_port("ws", None) is None


### PR DESCRIPTION
## Summary
- add an allow-listed fetch proxy with auditing utilities
- document the proxy in the README and threat model guidance
- cover the new security helper with dedicated unit tests

## Testing
- pre-commit run --all-files
- pytest --cov=gabriel --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_68fef54af2f8832fbfa388534539ef02