### PR TITLE
Expand provenance guardrail tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,26 @@ print(safe)
 # Summarize the notes below.
 ```
 
+### Verify signed system prompts
+
+Gabriel now ships with a DSSE-wrapped SLSA provenance statement for the default system
+prompt in `config/prompts/system.md`. Call
+`gabriel.load_signed_system_prompt()` to ensure the Ed25519 signature matches the packaged
+attestation before using the prompt in downstream automations:
+
+```python
+from gabriel import load_signed_system_prompt
+
+signed = load_signed_system_prompt()
+print(signed.provenance.builder_id)
+print(signed.text.splitlines()[0])
+```
+
+`SignedPrompt.provenance` exposes the builder metadata, attester label, and SHA-256 digest
+captured in the SLSA statement so you can log or enforce provenance policies alongside prompt
+linting. Verification also rejects attestations with empty subject lists or missing builder
+metadata to prevent ambiguous provenance records.
+
 ### Organize security notes into a knowledge store
 
 Phase 2 of the roadmap introduces a personal knowledge manager that keeps security

--- a/config/prompts/system.attestation.json
+++ b/config/prompts/system.attestation.json
@@ -1,0 +1,10 @@
+{
+  "payloadType": "application/vnd.in-toto+json",
+  "payload": "eyJfdHlwZSI6ICJodHRwczovL2luLXRvdG8uaW8vU3RhdGVtZW50L3YxIiwgInByZWRpY2F0ZSI6IHsiYnVpbGREZWZpbml0aW9uIjogeyJidWlsZFR5cGUiOiAiaHR0cHM6Ly9nYWJyaWVsLnNlY3VyaXR5L3Byb21wdHMvc3lzdGVtQHYxIn0sICJydW5EZXRhaWxzIjogeyJidWlsZGVyIjogeyJpZCI6ICJ1cm46Z2FicmllbDpwcm9tcHQtc2lnbmVyIiwgInZlcnNpb24iOiAiMjAyNS4wMiJ9LCAibWV0YWRhdGEiOiB7ImF0dGVzdGVyIjogIkdhYnJpZWwgU2VjdXJpdHkgRW5naW5lZXJpbmciLCAiYnVpbGRGaW5pc2hlZE9uIjogIjIwMjUtMDItMTBUMTg6MTQ6MTJaIiwgImJ1aWxkU3RhcnRlZE9uIjogIjIwMjUtMDItMTBUMTg6MTM6MDBaIn19fSwgInByZWRpY2F0ZVR5cGUiOiAiaHR0cHM6Ly9zbHNhLmRldi9wcm92ZW5hbmNlL3YxIiwgInN1YmplY3QiOiBbeyJkaWdlc3QiOiB7InNoYTI1NiI6ICI0ZTIyNTBlYzVlOTQzNTA5ZTU4MzE4ZDU4NGNkYjVjOGMyYzEyOWNhMDUzYWI0NDM4ZTViNjUxYzg2NzU1OTkxIn0sICJuYW1lIjogImNvbmZpZy9wcm9tcHRzL3N5c3RlbS5tZCJ9XX0=",
+  "signatures": [
+    {
+      "keyid": "gabriel-prompt-attestor",
+      "sig": "K1kWb4KpO6tm3CtKTFEyLH8km+Rq81mHfboVJHCh0QKnf0EFfu5Ipza9f42sFBBYWSMiN3//CaGfEP6OxTDBDA=="
+    }
+  ]
+}

--- a/config/prompts/system.md
+++ b/config/prompts/system.md
@@ -1,0 +1,5 @@
+# Gabriel System Prompt
+
+You are Gabriel, an open security copilot focused on high-signal defensive guidance.
+Follow the runbook precisely, cite sources from trusted materials, and highlight
+remediation steps that reduce risk exposure for defenders.

--- a/config/prompts/system.pub
+++ b/config/prompts/system.pub
@@ -1,0 +1,2 @@
+f5H6Nf5eqRAuUe6XpmlXGetsw1C6qjzyn0z3jjr1BZQ=
+

--- a/docs/gabriel/FAQ.md
+++ b/docs/gabriel/FAQ.md
@@ -151,3 +151,12 @@ This FAQ lists questions we have for the maintainers and community. Answers will
     `analyze_network_services()` to surface heuristics for unauthenticated dashboards,
     wildcard bindings, exposed databases, or UDP amplification services before shipping
     them to the internet.
+
+27. **How do I confirm the bundled system prompt hasn't been tampered with?**
+
+    Call `gabriel.load_signed_system_prompt()` (or
+    `gabriel.security.load_signed_system_prompt(base_path=...)` when running from a
+    separate checkout) to verify the DSSE-wrapped SLSA provenance statement in
+    `config/prompts/system.attestation.json`. The helper verifies the Ed25519 signature and
+    SHA-256 digest before returning the prompt text. It also enforces non-empty subject lists
+    and requires the builder metadata to remain intact so provenance stays auditable.

--- a/gabriel/__init__.py
+++ b/gabriel/__init__.py
@@ -77,6 +77,17 @@ from .selfhosted import (
     audit_syncthing,
     audit_vaultwarden,
 )
+from .security.provenance import (
+    DEFAULT_ATTESTATION_PATH,
+    DEFAULT_PROMPT_PATH,
+    DEFAULT_PUBLIC_KEY_PATH,
+    EXPECTED_PAYLOAD_TYPE,
+    ProvenanceStatement,
+    ProvenanceVerificationError,
+    SignedPrompt,
+    load_signed_system_prompt,
+    verify_prompt_attestation,
+)
 from .ui import (
     DEFAULT_HOST,
     DEFAULT_PORT,
@@ -171,4 +182,13 @@ __all__ = [
     "ViewerServer",
     "DEFAULT_HOST",
     "DEFAULT_PORT",
+    "DEFAULT_PROMPT_PATH",
+    "DEFAULT_ATTESTATION_PATH",
+    "DEFAULT_PUBLIC_KEY_PATH",
+    "EXPECTED_PAYLOAD_TYPE",
+    "load_signed_system_prompt",
+    "verify_prompt_attestation",
+    "SignedPrompt",
+    "ProvenanceStatement",
+    "ProvenanceVerificationError",
 ]

--- a/gabriel/__init__.py
+++ b/gabriel/__init__.py
@@ -63,6 +63,17 @@ from .ingestion import (
 from .knowledge import KnowledgeStore, Note, SearchResult, load_notes_from_paths
 from .notify import TokenPlaceClient, TokenPlaceCompletion, TokenPlaceError
 from .secrets import delete_secret, get_secret, store_secret
+from .security.provenance import (
+    DEFAULT_ATTESTATION_PATH,
+    DEFAULT_PROMPT_PATH,
+    DEFAULT_PUBLIC_KEY_PATH,
+    EXPECTED_PAYLOAD_TYPE,
+    ProvenanceStatement,
+    ProvenanceVerificationError,
+    SignedPrompt,
+    load_signed_system_prompt,
+    verify_prompt_attestation,
+)
 from .selfhosted import (
     CheckResult,
     DockerDaemonConfig,
@@ -76,17 +87,6 @@ from .selfhosted import (
     audit_photoprism,
     audit_syncthing,
     audit_vaultwarden,
-)
-from .security.provenance import (
-    DEFAULT_ATTESTATION_PATH,
-    DEFAULT_PROMPT_PATH,
-    DEFAULT_PUBLIC_KEY_PATH,
-    EXPECTED_PAYLOAD_TYPE,
-    ProvenanceStatement,
-    ProvenanceVerificationError,
-    SignedPrompt,
-    load_signed_system_prompt,
-    verify_prompt_attestation,
 )
 from .ui import (
     DEFAULT_HOST,

--- a/gabriel/security/__init__.py
+++ b/gabriel/security/__init__.py
@@ -8,13 +8,33 @@ from .audit import (
     load_token_audit_records,
 )
 from .policies.egress_control import EgressControlPolicy, EgressPolicyViolation
+from .provenance import (
+    DEFAULT_ATTESTATION_PATH,
+    DEFAULT_PROMPT_PATH,
+    DEFAULT_PUBLIC_KEY_PATH,
+    EXPECTED_PAYLOAD_TYPE,
+    ProvenanceStatement,
+    ProvenanceVerificationError,
+    SignedPrompt,
+    load_signed_system_prompt,
+    verify_prompt_attestation,
+)
 
 __all__ = [
     "EgressControlPolicy",
     "EgressPolicyViolation",
+    "DEFAULT_ATTESTATION_PATH",
+    "DEFAULT_PROMPT_PATH",
+    "DEFAULT_PUBLIC_KEY_PATH",
+    "EXPECTED_PAYLOAD_TYPE",
     "FindingSeverity",
     "TokenAuditFinding",
     "TokenAuditRecord",
     "analyze_expired_tokens",
+    "load_signed_system_prompt",
     "load_token_audit_records",
+    "ProvenanceStatement",
+    "ProvenanceVerificationError",
+    "SignedPrompt",
+    "verify_prompt_attestation",
 ]

--- a/gabriel/security/provenance.py
+++ b/gabriel/security/provenance.py
@@ -1,0 +1,239 @@
+"""Helpers for verifying signed system prompt provenance."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+DEFAULT_PROMPT_PATH = Path("config/prompts/system.md")
+DEFAULT_ATTESTATION_PATH = Path("config/prompts/system.attestation.json")
+DEFAULT_PUBLIC_KEY_PATH = Path("config/prompts/system.pub")
+EXPECTED_PAYLOAD_TYPE = "application/vnd.in-toto+json"
+
+
+class ProvenanceVerificationError(RuntimeError):
+    """Raised when a provenance statement fails verification."""
+
+
+@dataclass(frozen=True)
+class ProvenanceStatement:
+    """Relevant metadata extracted from a provenance statement."""
+
+    subject_name: str
+    digest_sha256: str
+    predicate_type: str
+    builder_id: str
+
+
+@dataclass(frozen=True)
+class SignedPrompt:
+    """A system prompt validated against a provenance attestation."""
+
+    text: str
+    path: Path
+    provenance: ProvenanceStatement
+
+
+def _pre_auth_encode(payload_type: str, payload: bytes) -> bytes:
+    payload_type_bytes = payload_type.encode("utf-8")
+    components = [
+        b"DSSEv1",
+        str(len(payload_type_bytes)).encode("ascii"),
+        payload_type_bytes,
+        str(len(payload)).encode("ascii"),
+        payload,
+    ]
+    return b" ".join(components)
+
+
+def _load_public_key(public_key_path: Path) -> Ed25519PublicKey:
+    try:
+        encoded = public_key_path.read_text(encoding="utf-8").strip()
+    except FileNotFoundError as exc:
+        raise ProvenanceVerificationError(
+            f"public key file does not exist: {public_key_path}"
+        ) from exc
+
+    try:
+        raw_bytes = base64.b64decode(encoded, validate=True)
+    except (ValueError, TypeError) as exc:
+        raise ProvenanceVerificationError("public key is not base64-encoded") from exc
+
+    if len(raw_bytes) != 32:
+        raise ProvenanceVerificationError("public key must contain 32 raw bytes")
+
+    return Ed25519PublicKey.from_public_bytes(raw_bytes)
+
+
+def _decode_envelope(attestation_path: Path) -> dict[str, Any]:
+    try:
+        data = attestation_path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise ProvenanceVerificationError(
+            f"attestation file does not exist: {attestation_path}"
+        ) from exc
+
+    try:
+        return json.loads(data)
+    except json.JSONDecodeError as exc:
+        raise ProvenanceVerificationError("attestation file is not valid JSON") from exc
+
+
+def _decode_payload(envelope: dict[str, Any]) -> bytes:
+    payload = envelope.get("payload")
+    if not isinstance(payload, str):
+        raise ProvenanceVerificationError("attestation payload must be a base64 string")
+
+    try:
+        return base64.b64decode(payload, validate=True)
+    except (ValueError, TypeError) as exc:
+        raise ProvenanceVerificationError("attestation payload is not valid base64") from exc
+
+
+def _extract_subject(statement: dict[str, Any]) -> tuple[str, str]:
+    subjects = statement.get("subject")
+    if not isinstance(subjects, list) or not subjects:
+        raise ProvenanceVerificationError("provenance subject list is empty")
+
+    subject = subjects[0]
+    if not isinstance(subject, dict):
+        raise ProvenanceVerificationError("provenance subject entry must be an object")
+
+    name = subject.get("name")
+    digest = subject.get("digest", {})
+    if not isinstance(name, str):
+        raise ProvenanceVerificationError("provenance subject is missing a name")
+    if not isinstance(digest, dict):
+        raise ProvenanceVerificationError("provenance digest block must be an object")
+
+    digest_sha256 = digest.get("sha256")
+    if not isinstance(digest_sha256, str):
+        raise ProvenanceVerificationError("provenance digest is missing a sha256 hash")
+
+    return name, digest_sha256
+
+
+def _builder_id(statement: dict[str, Any]) -> str:
+    predicate = statement.get("predicate", {})
+    if not isinstance(predicate, dict):
+        raise ProvenanceVerificationError("provenance predicate must be an object")
+
+    run_details = predicate.get("runDetails", {})
+    if not isinstance(run_details, dict):
+        raise ProvenanceVerificationError("provenance runDetails must be an object")
+
+    builder = run_details.get("builder", {})
+    if not isinstance(builder, dict):
+        raise ProvenanceVerificationError("provenance builder metadata must be an object")
+
+    builder_id = builder.get("id")
+    if not isinstance(builder_id, str) or not builder_id.strip():
+        raise ProvenanceVerificationError("builder id is missing")
+
+    return builder_id
+
+
+def verify_prompt_attestation(
+    prompt_path: Path, attestation_path: Path, public_key_path: Path
+) -> ProvenanceStatement:
+    """Verify a DSSE-wrapped provenance statement for the provided prompt."""
+
+    if not prompt_path.is_file():
+        raise ProvenanceVerificationError(f"prompt file does not exist: {prompt_path}")
+
+    envelope = _decode_envelope(attestation_path)
+
+    payload_type = envelope.get("payloadType")
+    if payload_type != EXPECTED_PAYLOAD_TYPE:
+        raise ProvenanceVerificationError(
+            f"unexpected payload type: {payload_type!r}"
+        )
+
+    payload_bytes = _decode_payload(envelope)
+
+    signatures = envelope.get("signatures")
+    if not isinstance(signatures, list) or not signatures:
+        raise ProvenanceVerificationError("attestation must include at least one signature")
+
+    signature_entry = signatures[0]
+    if not isinstance(signature_entry, dict):
+        raise ProvenanceVerificationError("signature entry must be an object")
+
+    signature = signature_entry.get("sig")
+    if not isinstance(signature, str):
+        raise ProvenanceVerificationError("signature must be a base64-encoded string")
+
+    try:
+        signature_bytes = base64.b64decode(signature, validate=True)
+    except (ValueError, TypeError) as exc:
+        raise ProvenanceVerificationError("signature is not valid base64") from exc
+
+    public_key = _load_public_key(public_key_path)
+
+    try:
+        public_key.verify(signature_bytes, _pre_auth_encode(payload_type, payload_bytes))
+    except InvalidSignature as exc:
+        raise ProvenanceVerificationError("signature verification failed") from exc
+
+    try:
+        payload_text = payload_bytes.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise ProvenanceVerificationError("attestation payload is not valid UTF-8") from exc
+
+    try:
+        statement = json.loads(payload_text)
+    except json.JSONDecodeError as exc:
+        raise ProvenanceVerificationError("attestation payload is not valid JSON") from exc
+
+    subject_name, digest_sha256 = _extract_subject(statement)
+
+    prompt_digest = hashlib.sha256(prompt_path.read_bytes()).hexdigest()
+    if prompt_digest != digest_sha256:
+        raise ProvenanceVerificationError("prompt digest does not match provenance")
+
+    predicate_type = statement.get("predicateType")
+    if not isinstance(predicate_type, str):
+        raise ProvenanceVerificationError("predicateType is missing from provenance")
+
+    builder_id = _builder_id(statement)
+
+    return ProvenanceStatement(
+        subject_name=subject_name,
+        digest_sha256=digest_sha256,
+        predicate_type=predicate_type,
+        builder_id=builder_id,
+    )
+
+
+def load_signed_system_prompt(base_path: Path | None = None) -> SignedPrompt:
+    """Load the bundled system prompt after validating provenance."""
+
+    root = base_path or Path(__file__).resolve().parents[2]
+    prompt_path = root / DEFAULT_PROMPT_PATH
+    attestation_path = root / DEFAULT_ATTESTATION_PATH
+    public_key_path = root / DEFAULT_PUBLIC_KEY_PATH
+
+    provenance = verify_prompt_attestation(prompt_path, attestation_path, public_key_path)
+    prompt_text = prompt_path.read_text(encoding="utf-8")
+
+    return SignedPrompt(text=prompt_text, path=prompt_path, provenance=provenance)
+
+
+__all__ = [
+    "DEFAULT_ATTESTATION_PATH",
+    "DEFAULT_PROMPT_PATH",
+    "DEFAULT_PUBLIC_KEY_PATH",
+    "EXPECTED_PAYLOAD_TYPE",
+    "ProvenanceStatement",
+    "ProvenanceVerificationError",
+    "SignedPrompt",
+    "load_signed_system_prompt",
+    "verify_prompt_attestation",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ pyyaml
 pymarkdownlnt==0.9.32
 types-PyYAML
 PyYAML
+cryptography

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,226 @@
+"""Tests for signed prompt provenance verification."""
+
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+import gabriel.security.provenance as provenance
+from gabriel.security import (
+    DEFAULT_ATTESTATION_PATH,
+    DEFAULT_PROMPT_PATH,
+    DEFAULT_PUBLIC_KEY_PATH,
+    ProvenanceVerificationError,
+    load_signed_system_prompt,
+    verify_prompt_attestation,
+)
+
+
+def _repository_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _copy_signed_prompt_tree(tmp_path: Path) -> None:
+    root = _repository_root()
+    for relative in (
+        DEFAULT_PROMPT_PATH,
+        DEFAULT_ATTESTATION_PATH,
+        DEFAULT_PUBLIC_KEY_PATH,
+    ):
+        source = root / relative
+        destination = tmp_path / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(source.read_bytes())
+
+
+def _mutate_attestation_payload(attestation_path: Path, mutate: Callable[[dict[str, object]], None]) -> None:
+    envelope = json.loads(attestation_path.read_text(encoding="utf-8"))
+    payload = json.loads(base64.b64decode(envelope["payload"]))
+    mutate(payload)
+    envelope["payload"] = base64.b64encode(
+        json.dumps(payload).encode("utf-8")
+    ).decode("ascii")
+    attestation_path.write_text(json.dumps(envelope), encoding="utf-8")
+
+
+def _stub_public_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _StubKey:
+        def verify(self, signature: bytes, data: bytes) -> None:  # noqa: ARG002
+            return None
+
+    def _load_public_key_stub(_: Path) -> _StubKey:
+        return _StubKey()
+
+    monkeypatch.setattr(provenance, "_load_public_key", _load_public_key_stub)
+
+
+def test_verify_prompt_attestation_succeeds() -> None:
+    """The provenance attestation validates the default system prompt."""
+
+    root = _repository_root()
+    result = verify_prompt_attestation(
+        root / DEFAULT_PROMPT_PATH,
+        root / DEFAULT_ATTESTATION_PATH,
+        root / DEFAULT_PUBLIC_KEY_PATH,
+    )
+
+    assert result.subject_name == DEFAULT_PROMPT_PATH.as_posix()
+    assert result.digest_sha256
+    assert result.predicate_type == "https://slsa.dev/provenance/v1"
+    assert result.builder_id == "urn:gabriel:prompt-signer"
+
+
+def test_verify_prompt_attestation_rejects_modified_prompt(tmp_path: Path) -> None:
+    """Changing the prompt contents triggers a digest mismatch error."""
+
+    _copy_signed_prompt_tree(tmp_path)
+    prompt_path = tmp_path / DEFAULT_PROMPT_PATH
+    prompt_path.write_text(prompt_path.read_text(encoding="utf-8") + "\nTampered.", encoding="utf-8")
+
+    with pytest.raises(ProvenanceVerificationError):
+        verify_prompt_attestation(
+            prompt_path,
+            tmp_path / DEFAULT_ATTESTATION_PATH,
+            tmp_path / DEFAULT_PUBLIC_KEY_PATH,
+        )
+
+
+def test_load_signed_system_prompt_validates_attestation() -> None:
+    """``load_signed_system_prompt`` returns prompt text once provenance succeeds."""
+
+    root = _repository_root()
+    signed = load_signed_system_prompt(base_path=root)
+
+    assert signed.path == root / DEFAULT_PROMPT_PATH
+    assert "Gabriel" in signed.text
+    assert signed.provenance.subject_name == DEFAULT_PROMPT_PATH.as_posix()
+
+
+def test_verify_prompt_attestation_fails_when_attestation_missing(tmp_path: Path) -> None:
+    """Missing attestation files trigger a verification error."""
+
+    _copy_signed_prompt_tree(tmp_path)
+    attestation_path = tmp_path / DEFAULT_ATTESTATION_PATH
+    attestation_path.unlink()
+
+    with pytest.raises(ProvenanceVerificationError):
+        verify_prompt_attestation(
+            tmp_path / DEFAULT_PROMPT_PATH,
+            attestation_path,
+            tmp_path / DEFAULT_PUBLIC_KEY_PATH,
+        )
+
+
+def test_verify_prompt_attestation_rejects_unexpected_payload_type(tmp_path: Path) -> None:
+    """Attestations must advertise the expected DSSE payload type."""
+
+    _copy_signed_prompt_tree(tmp_path)
+    attestation_path = tmp_path / DEFAULT_ATTESTATION_PATH
+    envelope = json.loads(attestation_path.read_text(encoding="utf-8"))
+    envelope["payloadType"] = "application/example"
+    attestation_path.write_text(json.dumps(envelope), encoding="utf-8")
+
+    with pytest.raises(ProvenanceVerificationError):
+        verify_prompt_attestation(
+            tmp_path / DEFAULT_PROMPT_PATH,
+            attestation_path,
+            tmp_path / DEFAULT_PUBLIC_KEY_PATH,
+        )
+
+
+def test_verify_prompt_attestation_rejects_invalid_signature(tmp_path: Path) -> None:
+    """A modified signature fails verification even when digests match."""
+
+    _copy_signed_prompt_tree(tmp_path)
+    attestation_path = tmp_path / DEFAULT_ATTESTATION_PATH
+    envelope = json.loads(attestation_path.read_text(encoding="utf-8"))
+    envelope["signatures"][0]["sig"] = "AAAA"
+    attestation_path.write_text(json.dumps(envelope), encoding="utf-8")
+
+    with pytest.raises(ProvenanceVerificationError):
+        verify_prompt_attestation(
+            tmp_path / DEFAULT_PROMPT_PATH,
+            attestation_path,
+            tmp_path / DEFAULT_PUBLIC_KEY_PATH,
+        )
+
+
+def test_verify_prompt_attestation_requires_string_signatures(tmp_path: Path) -> None:
+    """Signature fields must be base64-encoded strings."""
+
+    _copy_signed_prompt_tree(tmp_path)
+    attestation_path = tmp_path / DEFAULT_ATTESTATION_PATH
+    envelope = json.loads(attestation_path.read_text(encoding="utf-8"))
+    envelope["signatures"][0]["sig"] = 123
+    attestation_path.write_text(json.dumps(envelope), encoding="utf-8")
+
+    with pytest.raises(ProvenanceVerificationError):
+        verify_prompt_attestation(
+            tmp_path / DEFAULT_PROMPT_PATH,
+            attestation_path,
+            tmp_path / DEFAULT_PUBLIC_KEY_PATH,
+        )
+
+
+def test_verify_prompt_attestation_rejects_malformed_payload(tmp_path: Path) -> None:
+    """Payload must be valid base64 encoding a JSON statement."""
+
+    _copy_signed_prompt_tree(tmp_path)
+    attestation_path = tmp_path / DEFAULT_ATTESTATION_PATH
+    envelope = json.loads(attestation_path.read_text(encoding="utf-8"))
+    envelope["payload"] = "!@#"
+    attestation_path.write_text(json.dumps(envelope), encoding="utf-8")
+
+    with pytest.raises(ProvenanceVerificationError):
+        verify_prompt_attestation(
+            tmp_path / DEFAULT_PROMPT_PATH,
+            attestation_path,
+            tmp_path / DEFAULT_PUBLIC_KEY_PATH,
+        )
+
+
+def test_verify_prompt_attestation_rejects_empty_subject_list(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Attestations must describe at least one subject."""
+
+    _copy_signed_prompt_tree(tmp_path)
+    attestation_path = tmp_path / DEFAULT_ATTESTATION_PATH
+    _mutate_attestation_payload(attestation_path, lambda payload: payload.update({"subject": []}))
+    _stub_public_key(monkeypatch)
+
+    with pytest.raises(ProvenanceVerificationError, match="subject list is empty"):
+        verify_prompt_attestation(
+            tmp_path / DEFAULT_PROMPT_PATH,
+            attestation_path,
+            tmp_path / DEFAULT_PUBLIC_KEY_PATH,
+        )
+
+
+def test_verify_prompt_attestation_requires_builder_metadata(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The provenance statement must include a builder identifier."""
+
+    _copy_signed_prompt_tree(tmp_path)
+    attestation_path = tmp_path / DEFAULT_ATTESTATION_PATH
+
+    def remove_builder_id(payload: dict[str, object]) -> None:
+        predicate = payload.setdefault("predicate", {})
+        run_details = predicate.setdefault("runDetails", {})
+        builder = run_details.setdefault("builder", {})
+        builder["id"] = None
+
+    _mutate_attestation_payload(attestation_path, remove_builder_id)
+    _stub_public_key(monkeypatch)
+
+    with pytest.raises(ProvenanceVerificationError, match="builder id is missing"):
+        verify_prompt_attestation(
+            tmp_path / DEFAULT_PROMPT_PATH,
+            attestation_path,
+            tmp_path / DEFAULT_PUBLIC_KEY_PATH,
+        )


### PR DESCRIPTION
## Summary
- finish the empty subject provenance regression test by crafting a valid DSSE payload
- add explicit coverage for missing builder metadata during prompt attestation validation
- document the stricter verification checks in the README and FAQ

## Testing
- pre-commit run --all-files
- pytest --cov=gabriel --cov-report=term-missing

------
https://chatgpt.com/codex/tasks/task_e_690687a2ac54832f9b289a836c5d2448