### PR TITLE
feat: add CLI network exposure command

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,11 +70,16 @@ repos:
         args: [-c, pyproject.toml, -r, gabriel, scripts]
         additional_dependencies:
           - bandit[toml]
-  - repo: https://github.com/returntocorp/semgrep
-    rev: v1.69.0
+  - repo: local
     hooks:
       - id: semgrep
+        name: semgrep
+        entry: semgrep
+        language: python
+        additional_dependencies:
+          - semgrep==1.69.0
         args: ["--config", "config/semgrep/rules.yaml", "--error", "--metrics=off"]
+        types: [python]
   - repo: https://github.com/pypa/pip-audit
     rev: v2.9.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -316,6 +316,18 @@ internet, and UDP amplification targets that should stay rate-limited or
 disabled. Pair these findings with your existing firewall policies to confirm
 that sensitive services stay behind trusted networks.
 
+Run the same checks from the CLI by passing a JSON array of service definitions
+via a file or stdin. Use ``--output-format table`` for a condensed summary:
+
+```bash
+cat <<'JSON' | gabriel network --output-format table
+[
+  {"name": "Public Redis", "port": 6379, "exposure": "internet", "authenticated": false},
+  {"name": "Local Admin", "port": 8080, "exposure": "local", "address": "0.0.0.0"}
+]
+JSON
+```
+
 ### Review credential audit logs
 
 Use `gabriel.security.analyze_expired_tokens` to surface personal access tokens

--- a/docs/gabriel/FAQ.md
+++ b/docs/gabriel/FAQ.md
@@ -151,3 +151,9 @@ This FAQ lists questions we have for the maintainers and community. Answers will
     `analyze_network_services()` to surface heuristics for unauthenticated dashboards,
     wildcard bindings, exposed databases, or UDP amplification services before shipping
     them to the internet.
+
+27. **Is there a CLI shortcut for network exposure checks?**
+
+    Yes. Pipe a JSON array of service definitions into ``gabriel network`` or supply
+    ``--input`` with a file path. Add ``--output-format table`` for a condensed, human-
+    readable summary when triaging firewall changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ Issues = "https://github.com/futuroptimist/gabriel/issues"
 
 
 [project.optional-dependencies]
-docs = ["sphinx>=8.0.0", "sphinx-autodoc-typehints>=3.0.0"]
+docs = ["sphinx>=8.0.0,<9.0.0", "sphinx-autodoc-typehints>=3.0.0"]
 [project.scripts]
 gabriel = "gabriel.ui.cli:main"
 gabriel-calc = "gabriel.ui.cli:main"

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,9 @@ semgrep
 pyspelling
 mkdocs
 mkdocstrings[python]
-sphinx
+# Pin Sphinx below 9.0 until sphinx-autodoc-typehints gains compatibility with
+# newer releases (missing sphinx.ext.autodoc.mock on 9.0). See tests/test_sphinx_docs.py.
+sphinx<9
 sphinx-autodoc-typehints
 keyring
 hypothesis

--- a/tests/test_cli_network.py
+++ b/tests/test_cli_network.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+
+import pytest
+
+from gabriel.ui import cli
+
+
+def test_cli_network_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    services = [
+        {
+            "name": "Public Redis",
+            "port": 6379,
+            "exposure": "internet",
+            "authenticated": False,
+            "encrypted": False,
+        },
+        {
+            "name": "Local Admin",
+            "port": 8080,
+            "exposure": "local",
+            "address": "0.0.0.0",
+        },
+    ]
+    payload_path = tmp_path / "services.json"
+    payload_path.write_text(json.dumps(services), encoding="utf-8")
+
+    cli.main(["network", "--input", str(payload_path)])
+
+    output = json.loads(capsys.readouterr().out)
+    assert any(f["indicator"] == "internet-database" for f in output)
+    assert any(f["indicator"] == "unauthenticated-service" for f in output)
+    assert any(f["indicator"] == "wildcard-exposure" for f in output)
+
+
+def test_cli_network_table_output(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+    services = [
+        {
+            "name": "UDP Service",
+            "port": 123,
+            "protocol": "udp",
+            "exposure": "internet",
+            "encrypted": False,
+        }
+    ]
+
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO(json.dumps(services)))
+
+    cli.main(["network", "--output-format", "table"])
+
+    out = capsys.readouterr().out.strip()
+    assert "udp-amplification" in out
+    assert "UDP Service:123/udp (internet)" in out
+
+
+def test_cli_network_rejects_invalid_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO("not-json"))
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["network"])
+    assert "Invalid JSON" in str(excinfo.value)
+
+
+def test_cli_network_requires_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO("   "))
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["network"])
+    assert "Network service definitions are required" in str(excinfo.value)
+
+
+def test_cli_network_requires_array(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO("{}"))
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["network"])
+    assert "JSON array" in str(excinfo.value)
+
+
+def test_cli_network_rejects_non_dict_entry(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO("[1]"))
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["network"])
+    assert "JSON object" in str(excinfo.value)
+
+
+def test_cli_network_rejects_invalid_service(monkeypatch: pytest.MonkeyPatch) -> None:
+    service_payload = [{"name": "", "port": 80}]
+    monkeypatch.setattr(cli.sys, "stdin", io.StringIO(json.dumps(service_payload)))
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["network"])
+    assert "Invalid network service" in str(excinfo.value)

--- a/tests/test_cli_network.py
+++ b/tests/test_cli_network.py
@@ -36,7 +36,9 @@ def test_cli_network_json_output(tmp_path: Path, capsys: pytest.CaptureFixture[s
     assert any(f["indicator"] == "wildcard-exposure" for f in output)
 
 
-def test_cli_network_table_output(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]) -> None:
+def test_cli_network_table_output(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
     services = [
         {
             "name": "UDP Service",

--- a/tests/test_trufflehog_hook.py
+++ b/tests/test_trufflehog_hook.py
@@ -21,13 +21,14 @@ def test_trufflehog_hook_enabled() -> None:
     repos = config.get("repos", [])
 
     for repo in repos:
-        if repo.get("repo") == "local":
-            hooks = repo.get("hooks", [])
-            for hook in hooks:
-                if hook.get("id") == "trufflehog-scan":
-                    assert hook.get("language") == "python"
-                    assert "--max_depth" in hook.get("args", [])
-                    return
-            pytest.fail("Local hooks missing trufflehog-scan entry")
+        if repo.get("repo") != "local":
+            continue
 
-    pytest.fail("Local hook repository missing from pre-commit configuration")
+        hooks = repo.get("hooks", [])
+        for hook in hooks:
+            if hook.get("id") == "trufflehog-scan":
+                assert hook.get("language") == "python"
+                assert "--max_depth" in hook.get("args", [])
+                return
+
+    pytest.fail("Local hooks missing trufflehog-scan entry")


### PR DESCRIPTION
What: add a `gabriel network` CLI command that parses JSON inputs, renders
findings as JSON or a table, and document the workflow. Add CLI coverage tests
for happy paths and validation errors.
Why: surface the network monitoring roadmap helper directly in the CLI.
How to test: pytest --cov=gabriel --cov-report=term-missing; pre-commit run
--all-files
Refs: #

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692bfd4015bc832f9316e8649dec648b)