### PR TITLE
Fix recurring Security Scans dependency-audit failures by excluding scanner-only Semgrep from requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ packages, significantly reducing run time on repeat builds.
 
 Semgrep scans run alongside these hooks using the local rule bundle in
 [`config/semgrep/rules.yaml`](config/semgrep/rules.yaml) to flag risky subprocess usage in
-Python code before it lands in the repository.
+Python code before it lands in the repository. The pre-commit hook and security workflow install
+Semgrep in isolated tool environments, so `pip-audit` can audit Gabriel's Python dependency set
+without inheriting vulnerabilities from scanner-only dependencies.
 
 Ruff powers the lightweight linting layer used in both pre-commit hooks and CI. Run it directly
 when iterating on lint fixes:

--- a/docs/prompts/codex/scan-related-repositories.md
+++ b/docs/prompts/codex/scan-related-repositories.md
@@ -33,13 +33,13 @@ Tasks:
 - Commit the new docs.
 ```
 
-## [democratizedspace/dspace](https://github.com/democratizedspace/dspace/tree/v3)
+## [democratizedspace/dspace](https://github.com/democratizedspace/dspace)
 
 ```text
 You are Gabriel, a guardian-angel LLM.
 
 Tasks:
-- Clone https://github.com/democratizedspace/dspace and check out the `v3` branch (stay on `main` if the branch is unavailable).
+- Clone https://github.com/democratizedspace/dspace and use the default `main` branch.
 - Map the codebase to grasp architecture and goals.
 - Hunt for security vulnerabilities and misconfigurations.
 - Document findings in docs/security/vuln-<slug>.md with steps and fixes.

--- a/docs/related/dspace/IMPROVEMENTS.md
+++ b/docs/related/dspace/IMPROVEMENTS.md
@@ -1,7 +1,7 @@
 # Suggested Improvements for DSPACE
 
 This document tracks enhancement ideas for the
-[democratizedspace/dspace](https://github.com/democratizedspace/dspace/tree/v3) repository.
+[democratizedspace/dspace](https://github.com/democratizedspace/dspace) repository.
 
 ## Current Snapshot (2025-10-18)
 

--- a/outages/2026-02-02-pip-audit-semgrep-pyjwt.json
+++ b/outages/2026-02-02-pip-audit-semgrep-pyjwt.json
@@ -1,0 +1,11 @@
+{
+  "id": "pip-audit-semgrep-pyjwt",
+  "date": "2026-02-02",
+  "component": "Scheduled dependency audit",
+  "rootCause": "The requirements.txt dependency set included Semgrep, a scanner-only tool whose PyJWT transitive dependency was capped below the fixed 2.13.0 release, causing recurring pip-audit failures in the Security Scans workflow.",
+  "resolution": "Removed Semgrep from requirements.txt so the dependency audit covers Gabriel's Python dependency set while Semgrep continues to run from isolated pre-commit and GitHub Actions tool installs.",
+  "references": [
+    "https://github.com/futuroptimist/gabriel/actions/runs/20018430344",
+    "https://github.com/futuroptimist/gabriel/actions/runs/21579647496"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -575,9 +575,9 @@
       }
     },
     "node_modules/@commitlint/config-validator/node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1004,9 +1004,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1487,9 +1487,9 @@
       }
     },
     "node_modules/@tootallnate/once": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1721,9 +1721,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1971,9 +1971,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2998,9 +2998,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -3093,9 +3093,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -4532,10 +4532,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4749,9 +4759,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -4975,9 +4985,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -5285,9 +5295,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6564,9 +6574,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ detect-secrets
 publicsuffix2
 mypy
 pip-audit
-semgrep
 pyspelling
 mkdocs
 mkdocstrings[python]

--- a/tests/test_security_workflow.py
+++ b/tests/test_security_workflow.py
@@ -47,3 +47,11 @@ def test_security_workflow_runs_weekly_and_scans() -> None:
         isinstance(step, dict) and "npm audit" in str(step.get("run", ""))
         for step in dependency_steps
     ), "Dependency audit job must run npm audit"
+
+
+def test_requirements_exclude_scanner_only_semgrep_dependency() -> None:
+    """Keep dependency audits focused on Gabriel dependencies, not scanner tooling."""
+
+    requirements = Path("requirements.txt").read_text(encoding="utf-8").splitlines()
+
+    assert "semgrep" not in {line.strip() for line in requirements}  # nosec B101


### PR DESCRIPTION
### Motivation

- The scheduled `Security Scans` workflow was failing in the `Dependency Audits` job because `pip-audit --requirement requirements.txt` inherited Semgrep's scanner-only transitive `PyJWT` pin, producing repeated pip-audit failures.  
- A minimal, non-invasive change was needed so dependency audits cover Gabriel's runtime dependencies while Semgrep continues to run as a scanner from isolated tool installs.  

### Description

- Removed `semgrep` from `requirements.txt` so `pip-audit --requirement requirements.txt` audits only Gabriel runtime/developer dependencies and not scanner-only tooling.  
- Added a regression test `test_requirements_exclude_scanner_only_semgrep_dependency` to `tests/test_security_workflow.py` to prevent re-introducing scanner-only tools into `requirements.txt`.  
- Updated documentation to note that Semgrep is installed in isolated pre-commit/CI tool environments (`README.md`), fixed two stale dspace links in docs, refreshed dev transitive fixes via `npm audit fix --package-lock-only` (updated `package-lock.json`), and recorded the incident in `outages/2026-02-02-pip-audit-semgrep-pyjwt.json`.  

### Testing

- Ran dependency and tooling verification commands locally and observed passing results: `PYENV_VERSION=3.11.15 pip-audit --requirement requirements.txt` (No known vulnerabilities found).  
- Verified Node tooling and refresh: `npm ci --ignore-scripts` and `npm audit --audit-level=high` after `npm audit fix --package-lock-only` (no vulnerabilities reported).  
- Verified static analysis and pre-commit: `semgrep scan --config config/semgrep/rules.yaml --metrics=off` and `pre-commit run --all-files` (all hooks passed after the change).  
- Ran the full Python test suite and CI checks: `pytest --cov=gabriel --cov-report=term-missing` (369 passed, 1 skipped), `npm test -- --runInBand` (JS tests passed), and `npm run lint` (ESLint passed).  

Notes: `gh` CLI was not available in the execution environment so the GitHub REST API was used to inspect default-branch runs and triage which failures were current versus stale; the Docker Dependabot failure listed in older runs was superseded by a later successful run and was not changed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27c7916c88832f836dbf2a2ab7bbd1)