### PR TITLE
fix: update Trivy GitHub Action to v0.36.0 and add regression test

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
           load: true
           tags: ghcr.io/${{ github.repository }}:scan-${{ steps.platform-tag.outputs.tag }}
       - name: Scan image with Trivy (${{ matrix.platform }})
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: ghcr.io/${{ github.repository }}:scan-${{ steps.platform-tag.outputs.tag }}
           format: table

--- a/tests/test_tooling.py
+++ b/tests/test_tooling.py
@@ -195,6 +195,9 @@ def test_docker_workflow_scans_image_for_vulnerabilities() -> None:
         None,
     )
     assert trivy_step is not None, "Trivy scan step missing from Docker workflow"  # nosec B101
+    assert (
+        trivy_step.get("uses") == "aquasecurity/trivy-action@v0.36.0"
+    ), "Trivy action should use a resolvable v-prefixed release tag"  # nosec B101
 
     trivy_config = trivy_step.get("with", {})
     assert (


### PR DESCRIPTION
### Motivation
- The Docker workflow `scan` job was failing in run `27250213800` because `aquasecurity/trivy-action@0.20.0` could not be resolved, blocking image-scan setup.

### Description
- Updated `.github/workflows/docker.yml` to use `aquasecurity/trivy-action@v0.36.0`.
- Added a regression assertion in `tests/test_tooling.py` to ensure the Docker workflow continues to reference a resolvable v-prefixed Trivy action tag.

### Testing
- Verified the upstream tag exists with `git ls-remote --exit-code --tags https://github.com/aquasecurity/trivy-action.git refs/tags/v0.36.0` (succeeded).
- Ran targeted tests with `pytest tests/test_tooling.py::test_docker_workflow_scans_image_for_vulnerabilities tests/test_docker_workflow.py -q` (2 passed).
- Ran pre-commit with `pre-commit run --all-files` (passed).
- Ran full test suite with `pytest --cov=gabriel --cov-report=term-missing` (369 passed, 1 skipped) and coverage report generated (coverage.xml).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28e404d49c832f8c49dfd1a7f12107)