### PR TITLE
fix: pin Trivy action to resolvable release tag (v0.20.0)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
           load: true
           tags: ghcr.io/${{ github.repository }}:scan-${{ steps.platform-tag.outputs.tag }}
       - name: Scan image with Trivy (${{ matrix.platform }})
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@v0.20.0
         with:
           image-ref: ghcr.io/${{ github.repository }}:scan-${{ steps.platform-tag.outputs.tag }}
           format: table

--- a/tests/test_tooling.py
+++ b/tests/test_tooling.py
@@ -195,6 +195,9 @@ def test_docker_workflow_scans_image_for_vulnerabilities() -> None:
         None,
     )
     assert trivy_step is not None, "Trivy scan step missing from Docker workflow"  # nosec B101
+    assert (
+        trivy_step.get("uses") == "aquasecurity/trivy-action@v0.20.0"
+    ), "Trivy action should pin the valid v-prefixed release tag"  # nosec B101
 
     trivy_config = trivy_step.get("with", {})
     assert (


### PR DESCRIPTION
### Motivation
- The Docker workflow scan job was failing in CI because the Trivy action reference `aquasecurity/trivy-action@0.20.0` could not be resolved by GitHub Actions and broke the default-branch run.

### Description
- Update `.github/workflows/docker.yml` to use the valid release tag `aquasecurity/trivy-action@v0.20.0`.
- Add a regression assertion in `tests/test_tooling.py` to require the workflow to pin `aquasecurity/trivy-action@v0.20.0` so the resolver regression is caught by tests.
- Changes are limited to the workflow file and a single test that validates the workflow configuration.

### Testing
- Ran the targeted workflow tests with `python -m pytest tests/test_tooling.py::test_docker_workflow_scans_image_for_vulnerabilities tests/test_docker_workflow.py -q` and they passed.
- Ran repository checks with `pre-commit run --all-files` which completed successfully.
- Ran the full test suite with `pytest --cov=gabriel --cov-report=term-missing` which resulted in `369 passed, 1 skipped` and produced coverage reports.
- Limitations: Docker is not installed in the local environment so the actual Docker build/scan action could not be executed locally; the fix is minimal and targets the action tag resolution issue observed in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28e404d49c832f8c49dfd1a7f12107)