### PR TITLE
fix: use resolvable Trivy action tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,7 @@ jobs:
           load: true
           tags: ghcr.io/${{ github.repository }}:scan-${{ steps.platform-tag.outputs.tag }}
       - name: Scan image with Trivy (${{ matrix.platform }})
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@v0.20.0
         with:
           image-ref: ghcr.io/${{ github.repository }}:scan-${{ steps.platform-tag.outputs.tag }}
           format: table

--- a/tests/test_docker_workflow.py
+++ b/tests/test_docker_workflow.py
@@ -53,3 +53,24 @@ def test_docker_workflow_targets_multi_architectures(docker_workflow_path: Path)
     assert (
         not missing
     ), f"Docker build should target multi-arch platforms, missing: {missing}"  # nosec B101
+
+
+def test_docker_workflow_uses_resolvable_trivy_action_tag(docker_workflow_path: Path) -> None:
+    """Ensure the Trivy scan action reference matches upstream tag naming."""
+
+    workflow = yaml.safe_load(docker_workflow_path.read_text(encoding="utf-8"))
+    scan_job = workflow.get("jobs", {}).get("scan")
+    assert scan_job is not None, "Docker workflow must define a scan job"  # nosec B101
+
+    trivy_steps = [
+        step
+        for step in scan_job.get("steps", [])
+        if isinstance(step, dict)
+        and str(step.get("uses", "")).startswith("aquasecurity/trivy-action@")
+    ]
+    assert trivy_steps, "Docker workflow must invoke aquasecurity/trivy-action"  # nosec B101
+
+    action_ref = trivy_steps[-1]["uses"]
+    assert action_ref.startswith(
+        "aquasecurity/trivy-action@v"
+    ), "Trivy action tags are v-prefixed upstream"  # nosec B101


### PR DESCRIPTION
### Motivation
- The Docker workflow `scan` job failed during setup because the Trivy action reference `aquasecurity/trivy-action@0.20.0` could not be resolved upstream, causing the default-branch run to fail.  

### Description
- Updated the Trivy scan step in `.github/workflows/docker.yml` to use the upstream resolvable tag `aquasecurity/trivy-action@v0.20.0`.  
- Added a focused regression test `test_docker_workflow_uses_resolvable_trivy_action_tag` in `tests/test_docker_workflow.py` that asserts the workflow references a `v`-prefixed Trivy tag.  

### Testing
- Ran `pytest tests/test_docker_workflow.py` and the new test passed (`2 passed`).  
- Ran the full test suite `pytest --cov=gabriel --cov-report=term-missing` and all tests passed (`370 passed, 1 skipped`).  
- Ran `pre-commit run --all-files` and all hooks passed.  
- Verified upstream tag resolution via GitHub API checks showing `aquasecurity/trivy-action@0.20.0` returns `404` while `aquasecurity/trivy-action@v0.20.0` returns `200`.  
- Note: Docker is not installed in the local environment, so the actual build/push steps from the workflow could not be executed locally; the fix is limited to the resolvable action tag and a workflow-level unit test to prevent regressions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28e404d49c832f8c49dfd1a7f12107)